### PR TITLE
Stage one: create 3.0 version with minimal changes, add TypeScript, update tests to (partly) work.

### DIFF
--- a/js/mocks.js
+++ b/js/mocks.js
@@ -65,8 +65,8 @@ class XhrMock {
 }
 
 class CryptoMock {
-  static decrypt_output = "decrypted_message";
   constructor(window) {
+    this.decryptOutput = "decrypted_message";
     this.getRandomValues = jest.fn();
     this.subtle = {
       encrypt: jest.fn(),
@@ -74,7 +74,7 @@ class CryptoMock {
       importKey: jest.fn(),
     };
     let mockDecryptResponse = jest.fn();
-    mockDecryptResponse.mockImplementation((fn) => fn(CryptoMock.decrypt_output))
+    mockDecryptResponse.mockImplementation((fn) => fn(this.decryptOutput))
 
     this.subtle.decrypt.mockImplementation((settings, key, data) => {
       return {then: jest.fn().mockImplementation((func) => {
@@ -83,15 +83,15 @@ class CryptoMock {
       })}
     });
 
-    this.subtle.importKey.mockImplementation((format, key, algorithm, extractable, keyUsages) => {
-      return {then: jest.fn().mockImplementation((func) => {
+    this.subtle.importKey.mockImplementation((_format, _key, _algorithm, _extractable, _keyUsages) => {
+      return { then: jest.fn().mockImplementation((func) => {
         func("key");
-        return {catch: jest.fn()}
-      })}
+        return { catch: jest.fn() }
+      }) }
     });
 
     this.applyTo = (window) => {
-      window.crypto = this;
+      Object.defineProperty(window, 'crypto', { value: this });
     }
 
     this.applyTo(window);
@@ -180,4 +180,5 @@ module.exports = {
   getEuidCookie: getEuidCookie,
   makeIdentityV1: makeIdentityV1,
   makeIdentityV2: makeIdentityV2,
+  setupFakeTime
 };

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,11 +9,17 @@
       "version": "1.0.0",
       "license": "BSD",
       "devDependencies": {
+        "@types/jest": "^29.0.3",
+        "@types/node": "^18.7.18",
         "eslint": "^7.29.0",
         "eslint-plugin-import": "^2.23.4",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "eslint-plugin-testing-library": "^4.6.0",
-        "jest": "^27.5.1"
+        "jest": "^29.0.3",
+        "jest-environment-jsdom": "^29.0.3",
+        "jsdom": "^20.0.0",
+        "ts-jest": "^29.0.1",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -413,6 +419,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -663,59 +684,59 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
-      "integrity": "sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.0.3.tgz",
+      "integrity": "sha512-cGg0r+klVHSYnfE977S9wmpuQ9L+iYuYgL+5bPXiUlUynLLYunRxswEmhBzvrSKGof5AKiHuTTmUKAqRcDY9dg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/core": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.5.1.tgz",
-      "integrity": "sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.0.3.tgz",
+      "integrity": "sha512-1d0hLbOrM1qQE3eP3DtakeMbKTcXiXP3afWxqz103xPyddS2NhnNghS7MaXx1dcDt4/6p4nlhmeILo2ofgi8cQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.5.1",
-        "@jest/reporters": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/reporters": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "emittery": "^0.8.1",
+        "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^27.5.1",
-        "jest-config": "^27.5.1",
-        "jest-haste-map": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-resolve-dependencies": "^27.5.1",
-        "jest-runner": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
-        "jest-watcher": "^27.5.1",
+        "jest-changed-files": "^29.0.0",
+        "jest-config": "^29.0.3",
+        "jest-haste-map": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-regex-util": "^29.0.0",
+        "jest-resolve": "^29.0.3",
+        "jest-resolve-dependencies": "^29.0.3",
+        "jest-runner": "^29.0.3",
+        "jest-runtime": "^29.0.3",
+        "jest-snapshot": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
+        "jest-watcher": "^29.0.3",
         "micromatch": "^4.0.4",
-        "rimraf": "^3.0.0",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -727,85 +748,111 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
-      "integrity": "sha512-/WQjhPJe3/ghaol/4Bq480JKXV/Rfw8nQdN7f41fM8VDHLcxKXou6QyXAh3EFr9/bVG3x74z1NWDkP87EiY8gA==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.0.3.tgz",
+      "integrity": "sha512-iKl272NKxYNQNqXMQandAIwjhQaGw5uJfGXduu8dS9llHi8jV2ChWrtOAVPnMbaaoDhnI3wgUGNDvZgHeEJQCA==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
-        "jest-mock": "^27.5.1"
+        "jest-mock": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.0.3.tgz",
+      "integrity": "sha512-6W7K+fsI23FQ01H/BWccPyDZFrnU9QlzDcKOjrNVU5L8yUORFAJJIpmyxWPW70+X624KUNqzZwPThPMX28aXEQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.3",
+        "jest-snapshot": "^29.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.3.tgz",
+      "integrity": "sha512-i1xUkau7K/63MpdwiRqaxgZOjxYs4f0WMTGJnYwUKubsNRZSeQbLorS7+I4uXVF9KQ5r61BUPAUMZ7Lf66l64Q==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
-      "integrity": "sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.0.3.tgz",
+      "integrity": "sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
-        "@sinonjs/fake-timers": "^8.0.1",
+        "@jest/types": "^29.0.3",
+        "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "*",
-        "jest-message-util": "^27.5.1",
-        "jest-mock": "^27.5.1",
-        "jest-util": "^27.5.1"
+        "jest-message-util": "^29.0.3",
+        "jest-mock": "^29.0.3",
+        "jest-util": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
-      "integrity": "sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.0.3.tgz",
+      "integrity": "sha512-YqGHT65rFY2siPIHHFjuCGUsbzRjdqkwbat+Of6DmYRg5shIXXrLdZoVE/+TJ9O1dsKsFmYhU58JvIbZRU1Z9w==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "expect": "^27.5.1"
+        "@jest/environment": "^29.0.3",
+        "@jest/expect": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "jest-mock": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.5.1.tgz",
-      "integrity": "sha512-cPXh9hWIlVJMQkVk84aIvXuBB4uQQmFqZiacloFuGiP3ah1sbCxCosidXFDfqG8+6fO1oR2dTJTlsOy4VFmUfw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.0.3.tgz",
+      "integrity": "sha512-3+QU3d4aiyOWfmk1obDerie4XNCaD5Xo1IlKNde2yGEi02WQD+ZQD0i5Hgqm1e73sMV7kw6pMlCnprtEwEVwxw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@jridgewell/trace-mapping": "^0.3.15",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
-        "glob": "^7.1.2",
+        "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^5.1.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-haste-map": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-worker": "^27.5.1",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-worker": "^29.0.3",
         "slash": "^3.0.0",
-        "source-map": "^0.6.0",
         "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.1.0"
+        "v8-to-istanbul": "^9.0.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -816,90 +863,103 @@
         }
       }
     },
-    "node_modules/@jest/source-map": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
-      "integrity": "sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==",
+    "node_modules/@jest/schemas": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
       "dev": true,
       "dependencies": {
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9",
-        "source-map": "^0.6.0"
+        "@sinclair/typebox": "^0.24.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
+      "integrity": "sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.5.1.tgz",
-      "integrity": "sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.0.3.tgz",
+      "integrity": "sha512-vViVnQjCgTmbhDKEonKJPtcFe9G/CJO4/Np4XwYJah+lF2oI7KKeRp8t1dFvv44wN2NdbDb/qC6pi++Vpp0Dlg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.5.1.tgz",
-      "integrity": "sha512-LCheJF7WB2+9JuCS7VB/EmGIdQuhtqjRNI9A43idHv3E4KltCTsPsLxvdaubFHSYwY/fNjMWjl6vNRhDiN7vpQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.0.3.tgz",
+      "integrity": "sha512-Hf4+xYSWZdxTNnhDykr8JBs0yBN/nxOXyUQWfotBUqqy0LF9vzcFB0jm/EDNZCx587znLWTIgxcokW7WeZMobQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.5.1",
+        "@jest/test-result": "^29.0.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
-        "jest-runtime": "^27.5.1"
+        "jest-haste-map": "^29.0.3",
+        "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/transform": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.5.1.tgz",
-      "integrity": "sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.3.tgz",
+      "integrity": "sha512-C5ihFTRYaGDbi/xbRQRdbo5ddGtI4VSpmL6AIcZxdhwLbXMa7PcXxxqyI91vGOFHnn5aVM3WYnYKCHEqmLVGzg==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.1.0",
-        "@jest/types": "^27.5.1",
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.0.3",
+        "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-haste-map": "^29.0.3",
+        "jest-regex-util": "^29.0.0",
+        "jest-util": "^29.0.3",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "source-map": "^0.6.1",
-        "write-file-atomic": "^3.0.0"
+        "write-file-atomic": "^4.0.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.3.tgz",
+      "integrity": "sha512-coBJmOQvurXjN1Hh5PzF7cmsod0zLIOXpP8KD161mqNlroMhLcwpODiEzi7ZsRl5Z/AIuxpeNm8DCl43F4kz8A==",
       "dev": true,
       "dependencies": {
+        "@jest/schemas": "^29.0.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -984,6 +1044,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.24.42",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.42.tgz",
+      "integrity": "sha512-d+2AtrHGyWek2u2ITF0lHRIv6Tt7X0dEHW+0rP+5aDCEjC3fiN2RBjrLD0yU0at52BcZbRGxLbAtXiR0hFCjYw==",
+      "dev": true
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -994,21 +1060,21 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1085,6 +1151,27 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.3.tgz",
+      "integrity": "sha512-F6ukyCTwbfsEX5F2YmVYmM5TcTHy1q9P5rWlRbrk56KyMh3v9xRGUO3aa8+SkvMi0SHXtASJv1283enXimC0Og==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz",
+      "integrity": "sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -1115,10 +1202,16 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+      "integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -1268,9 +1361,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1478,22 +1571,21 @@
       "dev": true
     },
     "node_modules/babel-jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
-      "integrity": "sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.3.tgz",
+      "integrity": "sha512-ApPyHSOhS/sVzwUOQIWJmdvDhBsMG01HX9z7ogtkp1TToHGGUWFlnXJUIzCgKPSfiYLn3ibipCYzsKSURHEwLg==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/transform": "^29.0.3",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^27.5.1",
+        "babel-preset-jest": "^29.0.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
@@ -1516,18 +1608,18 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.5.1.tgz",
-      "integrity": "sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
+      "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.0.0",
+        "@types/babel__core": "^7.1.14",
         "@types/babel__traverse": "^7.0.6"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -1554,16 +1646,16 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
-      "integrity": "sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
+      "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^27.5.1",
+        "babel-plugin-jest-hoist": "^29.0.2",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -1631,6 +1723,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -1678,9 +1782,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001407",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
+      "integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==",
       "dev": true,
       "funding": [
         {
@@ -1817,9 +1921,9 @@
       }
     },
     "node_modules/cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
     "node_modules/cssstyle": {
@@ -1841,17 +1945,17 @@
       "dev": true
     },
     "node_modules/data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
       "dependencies": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -1872,9 +1976,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
-      "integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
+      "integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==",
       "dev": true
     },
     "node_modules/dedent": {
@@ -1933,12 +2037,12 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
+      "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
       "dev": true,
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -1966,39 +2070,30 @@
       }
     },
     "node_modules/domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "dev": true,
       "dependencies": {
-        "webidl-conversions": "^5.0.0"
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/domexception/node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.253",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.253.tgz",
-      "integrity": "sha512-1pezJ2E1UyBTGbA7fUlHdPSXQw1k+82VhTFLG5G0AUqLGvsZqFzleOblceqegZzxYX4kC7hGEEdzIQI9RZ1Cuw==",
+      "version": "1.4.256",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz",
+      "integrity": "sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==",
       "dev": true
     },
     "node_modules/emittery": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
-      "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+      "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
@@ -2020,6 +2115,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -2674,18 +2781,19 @@
       }
     },
     "node_modules/expect": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
-      "integrity": "sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.0.3.tgz",
+      "integrity": "sha512-t8l5DTws3212VbmPL+tBFXhjRHLmctHB0oQbL8eUc6S7NzZtYUhycrFO9mkxA0ZUC6FAWdNi7JchJSkODtcu1Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1"
+        "@jest/expect-utils": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "jest-matcher-utils": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2797,9 +2905,9 @@
       "dev": true
     },
     "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3084,15 +3192,15 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
       "dependencies": {
-        "whatwg-encoding": "^1.0.5"
+        "whatwg-encoding": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/html-escaper": {
@@ -3102,12 +3210,12 @@
       "dev": true
     },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "dependencies": {
-        "@tootallnate/once": "1",
+        "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
       },
@@ -3138,12 +3246,12 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -3465,12 +3573,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -3556,20 +3658,21 @@
       }
     },
     "node_modules/jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
-      "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.0.3.tgz",
+      "integrity": "sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.5.1",
+        "@jest/core": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.5.1"
+        "jest-cli": "^29.0.3"
       },
       "bin": {
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -3581,73 +3684,72 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.5.1.tgz",
-      "integrity": "sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.0.0.tgz",
+      "integrity": "sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
         "execa": "^5.0.0",
-        "throat": "^6.0.1"
+        "p-limit": "^3.1.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-circus": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.5.1.tgz",
-      "integrity": "sha512-D95R7x5UtlMA5iBYsOHFFbMD/GVA4R/Kdq15f7xYWUfWHBto9NYRsOvnSauTgdF+ogCpJ4tyKOXhUifxS65gdw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.0.3.tgz",
+      "integrity": "sha512-QeGzagC6Hw5pP+df1+aoF8+FBSgkPmraC1UdkeunWh0jmrp7wC0Hr6umdUAOELBQmxtKAOMNC3KAdjmCds92Zg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/expect": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.5.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "pretty-format": "^27.5.1",
+        "jest-each": "^29.0.3",
+        "jest-matcher-utils": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-runtime": "^29.0.3",
+        "jest-snapshot": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
-        "throat": "^6.0.1"
+        "stack-utils": "^2.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-cli": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.5.1.tgz",
-      "integrity": "sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.0.3.tgz",
+      "integrity": "sha512-aUy9Gd/Kut1z80eBzG10jAn6BgS3BoBbXyv+uXEqBJ8wnnuZ5RpNfARoskSrTIy1GY4a8f32YGuCMwibtkl9CQ==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/core": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
+        "jest-config": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
         "prompts": "^2.0.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.3.1"
       },
       "bin": {
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -3659,248 +3761,222 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
-      "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.0.3.tgz",
+      "integrity": "sha512-U5qkc82HHVYe3fNu2CRXLN4g761Na26rWKf7CjM8LlZB3In1jadEkZdMwsE37rd9RSPV0NfYaCjHdk/gu3v+Ew==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.8.0",
-        "@jest/test-sequencer": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "babel-jest": "^27.5.1",
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "babel-jest": "^29.0.3",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
-        "glob": "^7.1.1",
+        "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^27.5.1",
-        "jest-environment-jsdom": "^27.5.1",
-        "jest-environment-node": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-jasmine2": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-runner": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
+        "jest-circus": "^29.0.3",
+        "jest-environment-node": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-resolve": "^29.0.3",
+        "jest-runner": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^27.5.1",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
+        "@types/node": "*",
         "ts-node": ">=9.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
         "ts-node": {
           "optional": true
         }
       }
     },
     "node_modules/jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.3.tgz",
+      "integrity": "sha512-+X/AIF5G/vX9fWK+Db9bi9BQas7M9oBME7egU7psbn4jlszLFCu0dW63UgeE6cs/GANq4fLaT+8sGHQQ0eCUfg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "diff-sequences": "^29.0.0",
+        "jest-get-type": "^29.0.0",
+        "pretty-format": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
-      "integrity": "sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.0.0.tgz",
+      "integrity": "sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-each": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.5.1.tgz",
-      "integrity": "sha512-1Ff6p+FbhT/bXQnEouYy00bkNSY7OUpfIcmdl8vZ31A1UUaurOLPA8a8BbJOF2RDUElwJhmeaV7LnagI+5UwNQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.0.3.tgz",
+      "integrity": "sha512-wILhZfESURHHBNvPMJ0lZlYZrvOQJxAo3wNHi+ycr90V7M+uGR9Gh4+4a/BmaZF0XTyZsk4OiYEf3GJN7Ltqzg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "jest-get-type": "^29.0.0",
+        "jest-util": "^29.0.3",
+        "pretty-format": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.5.1.tgz",
-      "integrity": "sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.0.3.tgz",
+      "integrity": "sha512-KIGvpm12c71hoYTjL4wC2c8K6KfhOHJqJtaHc1IApu5rG047YWZoEP13BlbucWfzGISBrmli8KFqdhdQEa8Wnw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.5.1",
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@types/jsdom": "^20.0.0",
         "@types/node": "*",
-        "jest-mock": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jsdom": "^16.6.0"
+        "jest-mock": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jsdom": "^20.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
-      "integrity": "sha512-Jt4ZUnxdOsTGwSRAfKEnE6BcwsSPNOijjwifq5sDFSA2kesnXTvNqKHYgM0hDq3549Uf/KzdXNYn4wMZJPlFLw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.0.3.tgz",
+      "integrity": "sha512-cdZqRCnmIlTXC+9vtvmfiY/40Cj6s2T0czXuq1whvQdmpzAnj4sbqVYuZ4zFHk766xTTJ+Ij3uUqkk8KCfXoyg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.5.1",
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
-        "jest-mock": "^27.5.1",
-        "jest-util": "^27.5.1"
+        "jest-mock": "^29.0.3",
+        "jest-util": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
+      "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
       "dev": true,
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
-      "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.3.tgz",
+      "integrity": "sha512-uMqR99+GuBHo0RjRhOE4iA6LmsxEwRdgiIAQgMU/wdT2XebsLDz5obIwLZm/Psj+GwSEQhw9AfAVKGYbh2G55A==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
-        "@types/graceful-fs": "^4.1.2",
+        "@jest/types": "^29.0.3",
+        "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^27.5.1",
-        "jest-serializer": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-worker": "^27.5.1",
+        "jest-regex-util": "^29.0.0",
+        "jest-util": "^29.0.3",
+        "jest-worker": "^29.0.3",
         "micromatch": "^4.0.4",
-        "walker": "^1.0.7"
+        "walker": "^1.0.8"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
     },
-    "node_modules/jest-jasmine2": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz",
-      "integrity": "sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^27.5.1",
-        "@jest/source-map": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "expect": "^27.5.1",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "pretty-format": "^27.5.1",
-        "throat": "^6.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/jest-leak-detector": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
-      "integrity": "sha512-POXfWAMvfU6WMUXftV4HolnJfnPOGEu10fscNCA76KBpRRhcMN2c8d3iT2pxQS3HLbA+5X4sOUPzYO2NUyIlHQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.0.3.tgz",
+      "integrity": "sha512-YfW/G63dAuiuQ3QmQlh8hnqLDe25WFY3eQhuc/Ev1AGmkw5zREblTh7TCSKLoheyggu6G9gxO2hY8p9o6xbaRQ==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "jest-get-type": "^29.0.0",
+        "pretty-format": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.3.tgz",
+      "integrity": "sha512-RsR1+cZ6p1hDV4GSCQTg+9qjeotQCgkaleIKLK7dm+U4V/H2bWedU3RAtLm8+mANzZ7eDV33dMar4pejd7047w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "jest-diff": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "pretty-format": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
-      "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.0.3.tgz",
+      "integrity": "sha512-7T8JiUTtDfppojosORAflABfLsLKMLkBHSWkjNQrjIltGoDzNGn7wEPOSfjqYAGTYME65esQzMJxGDjuLBKdOg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.5.1",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-mock": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.5.1.tgz",
-      "integrity": "sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.0.3.tgz",
+      "integrity": "sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/node": "*"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -3921,158 +3997,145 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
+      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
       "dev": true,
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.5.1.tgz",
-      "integrity": "sha512-FFDy8/9E6CV83IMbDpcjOhumAQPDyETnU2KZ1O98DwTnz8AOBsW/Xv3GySr1mOZdItLR+zDZ7I/UdTFbgSOVCw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.0.3.tgz",
+      "integrity": "sha512-toVkia85Y/BPAjJasTC9zIPY6MmVXQPtrCk8SmiheC4MwVFE/CMFlOtMN6jrwPMC6TtNh8+sTMllasFeu1wMPg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
+        "jest-haste-map": "^29.0.3",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.5.1.tgz",
-      "integrity": "sha512-QQOOdY4PE39iawDn5rzbIePNigfe5B9Z91GDD1ae/xNDlu9kaat8QQ5EKnNmVWPV54hUdxCVwwj6YMgR2O7IOg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.0.3.tgz",
+      "integrity": "sha512-KzuBnXqNvbuCdoJpv8EanbIGObk7vUBNt/PwQPPx2aMhlv/jaXpUJsqWYRpP/0a50faMBY7WFFP8S3/CCzwfDw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-snapshot": "^27.5.1"
+        "jest-regex-util": "^29.0.0",
+        "jest-snapshot": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.5.1.tgz",
-      "integrity": "sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.0.3.tgz",
+      "integrity": "sha512-Usu6VlTOZlCZoNuh3b2Tv/yzDpKqtiNAetG9t3kJuHfUyVMNW7ipCCJOUojzKkjPoaN7Bl1f7Buu6PE0sGpQxw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.5.1",
-        "@jest/environment": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/environment": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "emittery": "^0.8.1",
+        "emittery": "^0.10.2",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^27.5.1",
-        "jest-environment-jsdom": "^27.5.1",
-        "jest-environment-node": "^27.5.1",
-        "jest-haste-map": "^27.5.1",
-        "jest-leak-detector": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-worker": "^27.5.1",
-        "source-map-support": "^0.5.6",
-        "throat": "^6.0.1"
+        "jest-docblock": "^29.0.0",
+        "jest-environment-node": "^29.0.3",
+        "jest-haste-map": "^29.0.3",
+        "jest-leak-detector": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-resolve": "^29.0.3",
+        "jest-runtime": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-watcher": "^29.0.3",
+        "jest-worker": "^29.0.3",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runtime": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.5.1.tgz",
-      "integrity": "sha512-o7gxw3Gf+H2IGt8fv0RiyE1+r83FJBRruoA+FXrlHw6xEyBsU8ugA6IPfTdVyA0w8HClpbK+DGJxH59UrNMx8A==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.0.3.tgz",
+      "integrity": "sha512-12gZXRQ7ozEeEHKTY45a+YLqzNDR/x4c//X6AqwKwKJPpWM8FY4vwn4VQJOcLRS3Nd1fWwgP7LU4SoynhuUMHQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.5.1",
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/globals": "^27.5.1",
-        "@jest/source-map": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/globals": "^29.0.3",
+        "@jest/source-map": "^29.0.0",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
-        "execa": "^5.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-mock": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-haste-map": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-mock": "^29.0.3",
+        "jest-regex-util": "^29.0.0",
+        "jest-resolve": "^29.0.3",
+        "jest-snapshot": "^29.0.3",
+        "jest-util": "^29.0.3",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-serializer": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.5.1.tgz",
-      "integrity": "sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "graceful-fs": "^4.2.9"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.5.1.tgz",
-      "integrity": "sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.0.3.tgz",
+      "integrity": "sha512-52q6JChm04U3deq+mkQ7R/7uy7YyfVIrebMi6ZkBoDJ85yEjm/sJwdr1P0LOIEHmpyLlXrxy3QP0Zf5J2kj0ew==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.7.2",
+        "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
-        "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "@types/babel__traverse": "^7.0.4",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.5.1",
+        "expect": "^29.0.3",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-haste-map": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-diff": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "jest-haste-map": "^29.0.3",
+        "jest-matcher-utils": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.5.1",
-        "semver": "^7.3.2"
+        "pretty-format": "^29.0.3",
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
@@ -4091,12 +4154,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
-      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.3.tgz",
+      "integrity": "sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -4104,24 +4167,24 @@
         "picomatch": "^2.2.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-validate": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.5.1.tgz",
-      "integrity": "sha512-thkNli0LYTmOI1tDB3FI1S1RTp/Bqyd9pTarJwL87OIBFuqEb5Apv5EaApEudYg4g86e3CT6kM0RowkhtEnCBQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.0.3.tgz",
+      "integrity": "sha512-OebiqqT6lK8cbMPtrSoS3aZP4juID762lZvpf1u+smZnwTEBCBInan0GAIIhv36MxGaJvmq5uJm7dl5gVt+Zrw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.5.1",
+        "jest-get-type": "^29.0.0",
         "leven": "^3.1.0",
-        "pretty-format": "^27.5.1"
+        "pretty-format": "^29.0.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-validate/node_modules/camelcase": {
@@ -4137,27 +4200,28 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.5.1.tgz",
-      "integrity": "sha512-z676SuD6Z8o8qbmEGhoEUFOM1+jfEiL3DXHK/xgEiG2EyNYfFG60jluWcupY6dATjfEsKQuibReS1djInQnoVw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.0.3.tgz",
+      "integrity": "sha512-tQX9lU91A+9tyUQKUMp0Ns8xAcdhC9fo73eqA3LFxP2bSgiF49TNcc+vf3qgGYYK9qRjFpXW9+4RgF/mbxyOOw==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/test-result": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.5.1",
+        "emittery": "^0.10.2",
+        "jest-util": "^29.0.3",
         "string-length": "^4.0.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.3.tgz",
+      "integrity": "sha512-Tl/YWUugQOjoTYwjKdfJWkSOfhufJHO5LhXTSZC3TRoQKO+fuXnZAdoXXBlpLXKGODBL3OvdUasfDD4PcMe6ng==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -4165,7 +4229,7 @@
         "supports-color": "^8.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker/node_modules/supports-color": {
@@ -4203,41 +4267,41 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.0.tgz",
+      "integrity": "sha512-x4a6CKCgx00uCmP+QakBDFXwjAJ69IkkIWHmtmjd3wvXPcdOS44hfX2vqkOQrVrq8l9DhNNADZRXaCEWvgXtVA==",
       "dev": true,
       "dependencies": {
-        "abab": "^2.0.5",
-        "acorn": "^8.2.4",
+        "abab": "^2.0.6",
+        "acorn": "^8.7.1",
         "acorn-globals": "^6.0.0",
-        "cssom": "^0.4.4",
+        "cssom": "^0.5.0",
         "cssstyle": "^2.3.0",
-        "data-urls": "^2.0.0",
-        "decimal.js": "^10.2.1",
-        "domexception": "^2.0.1",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.3.1",
+        "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
-        "form-data": "^3.0.0",
-        "html-encoding-sniffer": "^2.0.1",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
+        "parse5": "^7.0.0",
+        "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.0.0",
         "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^2.0.0",
-        "webidl-conversions": "^6.1.0",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.5.0",
-        "ws": "^7.4.6",
-        "xml-name-validator": "^3.0.0"
+        "w3c-xmlserializer": "^3.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.8.0",
+        "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "peerDependencies": {
         "canvas": "^2.5.0"
@@ -4339,16 +4403,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -4389,6 +4453,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4621,15 +4691,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4645,6 +4715,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -4687,10 +4772,16 @@
       }
     },
     "node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
+      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -4783,17 +4874,17 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.0.3.tgz",
+      "integrity": "sha512-cHudsvQr1K5vNVLbvYF/nv3Qy/F/BcEKxGuIeMiVMRHxPOO1RxXooP8g/ZrwAp7Dx+KdMZoOc7NxLHhMrP2f9Q==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.0.0",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -4872,9 +4963,9 @@
       ]
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
@@ -5034,15 +5125,15 @@
       "dev": true
     },
     "node_modules/saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -5137,9 +5228,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -5376,12 +5467,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "node_modules/throat": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
-      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
-      "dev": true
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5425,15 +5510,73 @@
       }
     },
     "node_modules/tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.1.tgz",
+      "integrity": "sha512-htQOHshgvhn93QLxrmxpiQPk69+M1g7govO1g6kf6GsjCv4uvRV0znVmDrrvjUrVCnTYeY4FBxTYYYD4airyJA==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -5523,21 +5666,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5622,26 +5755,17 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
-      "integrity": "sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0",
-        "source-map": "^0.7.3"
+        "convert-source-map": "^1.6.0"
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/v8-to-istanbul/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -5654,15 +5778,15 @@
       }
     },
     "node_modules/w3c-xmlserializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
+      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
       "dev": true,
       "dependencies": {
-        "xml-name-validator": "^3.0.0"
+        "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/walker": {
@@ -5675,41 +5799,46 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "engines": {
-        "node": ">=10.4"
+        "node": ">=12"
       }
     },
     "node_modules/whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
       "dependencies": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -5776,24 +5905,25 @@
       "dev": true
     },
     "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -5809,10 +5939,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -5836,30 +5969,42 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -6165,6 +6310,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -6354,193 +6508,223 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
-      "integrity": "sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.0.3.tgz",
+      "integrity": "sha512-cGg0r+klVHSYnfE977S9wmpuQ9L+iYuYgL+5bPXiUlUynLLYunRxswEmhBzvrSKGof5AKiHuTTmUKAqRcDY9dg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.5.1.tgz",
-      "integrity": "sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.0.3.tgz",
+      "integrity": "sha512-1d0hLbOrM1qQE3eP3DtakeMbKTcXiXP3afWxqz103xPyddS2NhnNghS7MaXx1dcDt4/6p4nlhmeILo2ofgi8cQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.5.1",
-        "@jest/reporters": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/reporters": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "emittery": "^0.8.1",
+        "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^27.5.1",
-        "jest-config": "^27.5.1",
-        "jest-haste-map": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-resolve-dependencies": "^27.5.1",
-        "jest-runner": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
-        "jest-watcher": "^27.5.1",
+        "jest-changed-files": "^29.0.0",
+        "jest-config": "^29.0.3",
+        "jest-haste-map": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-regex-util": "^29.0.0",
+        "jest-resolve": "^29.0.3",
+        "jest-resolve-dependencies": "^29.0.3",
+        "jest-runner": "^29.0.3",
+        "jest-runtime": "^29.0.3",
+        "jest-snapshot": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
+        "jest-watcher": "^29.0.3",
         "micromatch": "^4.0.4",
-        "rimraf": "^3.0.0",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       }
     },
     "@jest/environment": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
-      "integrity": "sha512-/WQjhPJe3/ghaol/4Bq480JKXV/Rfw8nQdN7f41fM8VDHLcxKXou6QyXAh3EFr9/bVG3x74z1NWDkP87EiY8gA==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.0.3.tgz",
+      "integrity": "sha512-iKl272NKxYNQNqXMQandAIwjhQaGw5uJfGXduu8dS9llHi8jV2ChWrtOAVPnMbaaoDhnI3wgUGNDvZgHeEJQCA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
-        "jest-mock": "^27.5.1"
+        "jest-mock": "^29.0.3"
+      }
+    },
+    "@jest/expect": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.0.3.tgz",
+      "integrity": "sha512-6W7K+fsI23FQ01H/BWccPyDZFrnU9QlzDcKOjrNVU5L8yUORFAJJIpmyxWPW70+X624KUNqzZwPThPMX28aXEQ==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.3",
+        "jest-snapshot": "^29.0.3"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.3.tgz",
+      "integrity": "sha512-i1xUkau7K/63MpdwiRqaxgZOjxYs4f0WMTGJnYwUKubsNRZSeQbLorS7+I4uXVF9KQ5r61BUPAUMZ7Lf66l64Q==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.0.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
-      "integrity": "sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.0.3.tgz",
+      "integrity": "sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
-        "@sinonjs/fake-timers": "^8.0.1",
+        "@jest/types": "^29.0.3",
+        "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "*",
-        "jest-message-util": "^27.5.1",
-        "jest-mock": "^27.5.1",
-        "jest-util": "^27.5.1"
+        "jest-message-util": "^29.0.3",
+        "jest-mock": "^29.0.3",
+        "jest-util": "^29.0.3"
       }
     },
     "@jest/globals": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
-      "integrity": "sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.0.3.tgz",
+      "integrity": "sha512-YqGHT65rFY2siPIHHFjuCGUsbzRjdqkwbat+Of6DmYRg5shIXXrLdZoVE/+TJ9O1dsKsFmYhU58JvIbZRU1Z9w==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "expect": "^27.5.1"
+        "@jest/environment": "^29.0.3",
+        "@jest/expect": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "jest-mock": "^29.0.3"
       }
     },
     "@jest/reporters": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.5.1.tgz",
-      "integrity": "sha512-cPXh9hWIlVJMQkVk84aIvXuBB4uQQmFqZiacloFuGiP3ah1sbCxCosidXFDfqG8+6fO1oR2dTJTlsOy4VFmUfw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.0.3.tgz",
+      "integrity": "sha512-3+QU3d4aiyOWfmk1obDerie4XNCaD5Xo1IlKNde2yGEi02WQD+ZQD0i5Hgqm1e73sMV7kw6pMlCnprtEwEVwxw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@jridgewell/trace-mapping": "^0.3.15",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
-        "glob": "^7.1.2",
+        "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^5.1.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-haste-map": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-worker": "^27.5.1",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-worker": "^29.0.3",
         "slash": "^3.0.0",
-        "source-map": "^0.6.0",
         "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.1.0"
+        "v8-to-istanbul": "^9.0.1"
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.24.1"
       }
     },
     "@jest/source-map": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
-      "integrity": "sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
+      "integrity": "sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==",
       "dev": true,
       "requires": {
+        "@jridgewell/trace-mapping": "^0.3.15",
         "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9",
-        "source-map": "^0.6.0"
+        "graceful-fs": "^4.2.9"
       }
     },
     "@jest/test-result": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.5.1.tgz",
-      "integrity": "sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.0.3.tgz",
+      "integrity": "sha512-vViVnQjCgTmbhDKEonKJPtcFe9G/CJO4/Np4XwYJah+lF2oI7KKeRp8t1dFvv44wN2NdbDb/qC6pi++Vpp0Dlg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.5.1.tgz",
-      "integrity": "sha512-LCheJF7WB2+9JuCS7VB/EmGIdQuhtqjRNI9A43idHv3E4KltCTsPsLxvdaubFHSYwY/fNjMWjl6vNRhDiN7vpQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.0.3.tgz",
+      "integrity": "sha512-Hf4+xYSWZdxTNnhDykr8JBs0yBN/nxOXyUQWfotBUqqy0LF9vzcFB0jm/EDNZCx587znLWTIgxcokW7WeZMobQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.5.1",
+        "@jest/test-result": "^29.0.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
-        "jest-runtime": "^27.5.1"
+        "jest-haste-map": "^29.0.3",
+        "slash": "^3.0.0"
       }
     },
     "@jest/transform": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.5.1.tgz",
-      "integrity": "sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.3.tgz",
+      "integrity": "sha512-C5ihFTRYaGDbi/xbRQRdbo5ddGtI4VSpmL6AIcZxdhwLbXMa7PcXxxqyI91vGOFHnn5aVM3WYnYKCHEqmLVGzg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/types": "^27.5.1",
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.0.3",
+        "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-haste-map": "^29.0.3",
+        "jest-regex-util": "^29.0.0",
+        "jest-util": "^29.0.3",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "source-map": "^0.6.1",
-        "write-file-atomic": "^3.0.0"
+        "write-file-atomic": "^4.0.1"
       }
     },
     "@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.3.tgz",
+      "integrity": "sha512-coBJmOQvurXjN1Hh5PzF7cmsod0zLIOXpP8KD161mqNlroMhLcwpODiEzi7ZsRl5Z/AIuxpeNm8DCl43F4kz8A==",
       "dev": true,
       "requires": {
+        "@jest/schemas": "^29.0.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       }
     },
@@ -6608,6 +6792,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sinclair/typebox": {
+      "version": "0.24.42",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.42.tgz",
+      "integrity": "sha512-d+2AtrHGyWek2u2ITF0lHRIv6Tt7X0dEHW+0rP+5aDCEjC3fiN2RBjrLD0yU0at52BcZbRGxLbAtXiR0hFCjYw==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -6618,18 +6808,18 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
     },
     "@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -6706,6 +6896,27 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.3.tgz",
+      "integrity": "sha512-F6ukyCTwbfsEX5F2YmVYmM5TcTHy1q9P5rWlRbrk56KyMh3v9xRGUO3aa8+SkvMi0SHXtASJv1283enXimC0Og==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "@types/jsdom": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz",
+      "integrity": "sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -6736,10 +6947,16 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
     "@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+      "integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -6835,9 +7052,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-globals": {
@@ -6984,16 +7201,15 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
-      "integrity": "sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.3.tgz",
+      "integrity": "sha512-ApPyHSOhS/sVzwUOQIWJmdvDhBsMG01HX9z7ogtkp1TToHGGUWFlnXJUIzCgKPSfiYLn3ibipCYzsKSURHEwLg==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/transform": "^29.0.3",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^27.5.1",
+        "babel-preset-jest": "^29.0.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -7013,14 +7229,14 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.5.1.tgz",
-      "integrity": "sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
+      "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.0.0",
+        "@types/babel__core": "^7.1.14",
         "@types/babel__traverse": "^7.0.6"
       }
     },
@@ -7045,12 +7261,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
-      "integrity": "sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
+      "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.5.1",
+        "babel-plugin-jest-hoist": "^29.0.2",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -7097,6 +7313,15 @@
         "update-browserslist-db": "^1.0.9"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -7135,9 +7360,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001407",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
+      "integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==",
       "dev": true
     },
     "chalk": {
@@ -7242,9 +7467,9 @@
       }
     },
     "cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
     "cssstyle": {
@@ -7265,14 +7490,14 @@
       }
     },
     "data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
       }
     },
     "debug": {
@@ -7285,9 +7510,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
-      "integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
+      "integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==",
       "dev": true
     },
     "dedent": {
@@ -7331,9 +7556,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
+      "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
       "dev": true
     },
     "dir-glob": {
@@ -7355,32 +7580,24 @@
       }
     },
     "domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "^5.0.0"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-          "dev": true
-        }
+        "webidl-conversions": "^7.0.0"
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.253",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.253.tgz",
-      "integrity": "sha512-1pezJ2E1UyBTGbA7fUlHdPSXQw1k+82VhTFLG5G0AUqLGvsZqFzleOblceqegZzxYX4kC7hGEEdzIQI9RZ1Cuw==",
+      "version": "1.4.256",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz",
+      "integrity": "sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==",
       "dev": true
     },
     "emittery": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
-      "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+      "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
       "dev": true
     },
     "emoji-regex": {
@@ -7397,6 +7614,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -7892,15 +8115,16 @@
       "dev": true
     },
     "expect": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
-      "integrity": "sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.0.3.tgz",
+      "integrity": "sha512-t8l5DTws3212VbmPL+tBFXhjRHLmctHB0oQbL8eUc6S7NzZtYUhycrFO9mkxA0ZUC6FAWdNi7JchJSkODtcu1Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1"
+        "@jest/expect-utils": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "jest-matcher-utils": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3"
       }
     },
     "fast-deep-equal": {
@@ -7997,9 +8221,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -8198,12 +8422,12 @@
       }
     },
     "html-encoding-sniffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.5"
+        "whatwg-encoding": "^2.0.0"
       }
     },
     "html-escaper": {
@@ -8213,12 +8437,12 @@
       "dev": true
     },
     "http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "requires": {
-        "@tootallnate/once": "1",
+        "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
       }
@@ -8240,12 +8464,12 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "ignore": {
@@ -8461,12 +8685,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
-    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -8534,267 +8752,240 @@
       }
     },
     "jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
-      "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.0.3.tgz",
+      "integrity": "sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.5.1",
+        "@jest/core": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.5.1"
+        "jest-cli": "^29.0.3"
       }
     },
     "jest-changed-files": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.5.1.tgz",
-      "integrity": "sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.0.0.tgz",
+      "integrity": "sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
         "execa": "^5.0.0",
-        "throat": "^6.0.1"
+        "p-limit": "^3.1.0"
       }
     },
     "jest-circus": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.5.1.tgz",
-      "integrity": "sha512-D95R7x5UtlMA5iBYsOHFFbMD/GVA4R/Kdq15f7xYWUfWHBto9NYRsOvnSauTgdF+ogCpJ4tyKOXhUifxS65gdw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.0.3.tgz",
+      "integrity": "sha512-QeGzagC6Hw5pP+df1+aoF8+FBSgkPmraC1UdkeunWh0jmrp7wC0Hr6umdUAOELBQmxtKAOMNC3KAdjmCds92Zg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/expect": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.5.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "pretty-format": "^27.5.1",
+        "jest-each": "^29.0.3",
+        "jest-matcher-utils": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-runtime": "^29.0.3",
+        "jest-snapshot": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
-        "throat": "^6.0.1"
+        "stack-utils": "^2.0.3"
       }
     },
     "jest-cli": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.5.1.tgz",
-      "integrity": "sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.0.3.tgz",
+      "integrity": "sha512-aUy9Gd/Kut1z80eBzG10jAn6BgS3BoBbXyv+uXEqBJ8wnnuZ5RpNfARoskSrTIy1GY4a8f32YGuCMwibtkl9CQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/core": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
+        "jest-config": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
         "prompts": "^2.0.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.3.1"
       }
     },
     "jest-config": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
-      "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.0.3.tgz",
+      "integrity": "sha512-U5qkc82HHVYe3fNu2CRXLN4g761Na26rWKf7CjM8LlZB3In1jadEkZdMwsE37rd9RSPV0NfYaCjHdk/gu3v+Ew==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.8.0",
-        "@jest/test-sequencer": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "babel-jest": "^27.5.1",
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "babel-jest": "^29.0.3",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
-        "glob": "^7.1.1",
+        "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^27.5.1",
-        "jest-environment-jsdom": "^27.5.1",
-        "jest-environment-node": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-jasmine2": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-runner": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
+        "jest-circus": "^29.0.3",
+        "jest-environment-node": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-resolve": "^29.0.3",
+        "jest-runner": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^27.5.1",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       }
     },
     "jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.3.tgz",
+      "integrity": "sha512-+X/AIF5G/vX9fWK+Db9bi9BQas7M9oBME7egU7psbn4jlszLFCu0dW63UgeE6cs/GANq4fLaT+8sGHQQ0eCUfg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "diff-sequences": "^29.0.0",
+        "jest-get-type": "^29.0.0",
+        "pretty-format": "^29.0.3"
       }
     },
     "jest-docblock": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
-      "integrity": "sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.0.0.tgz",
+      "integrity": "sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.5.1.tgz",
-      "integrity": "sha512-1Ff6p+FbhT/bXQnEouYy00bkNSY7OUpfIcmdl8vZ31A1UUaurOLPA8a8BbJOF2RDUElwJhmeaV7LnagI+5UwNQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.0.3.tgz",
+      "integrity": "sha512-wILhZfESURHHBNvPMJ0lZlYZrvOQJxAo3wNHi+ycr90V7M+uGR9Gh4+4a/BmaZF0XTyZsk4OiYEf3GJN7Ltqzg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "jest-get-type": "^29.0.0",
+        "jest-util": "^29.0.3",
+        "pretty-format": "^29.0.3"
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.5.1.tgz",
-      "integrity": "sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.0.3.tgz",
+      "integrity": "sha512-KIGvpm12c71hoYTjL4wC2c8K6KfhOHJqJtaHc1IApu5rG047YWZoEP13BlbucWfzGISBrmli8KFqdhdQEa8Wnw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.5.1",
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@types/jsdom": "^20.0.0",
         "@types/node": "*",
-        "jest-mock": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jsdom": "^16.6.0"
+        "jest-mock": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jsdom": "^20.0.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
-      "integrity": "sha512-Jt4ZUnxdOsTGwSRAfKEnE6BcwsSPNOijjwifq5sDFSA2kesnXTvNqKHYgM0hDq3549Uf/KzdXNYn4wMZJPlFLw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.0.3.tgz",
+      "integrity": "sha512-cdZqRCnmIlTXC+9vtvmfiY/40Cj6s2T0czXuq1whvQdmpzAnj4sbqVYuZ4zFHk766xTTJ+Ij3uUqkk8KCfXoyg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.5.1",
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
-        "jest-mock": "^27.5.1",
-        "jest-util": "^27.5.1"
+        "jest-mock": "^29.0.3",
+        "jest-util": "^29.0.3"
       }
     },
     "jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
+      "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
-      "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.3.tgz",
+      "integrity": "sha512-uMqR99+GuBHo0RjRhOE4iA6LmsxEwRdgiIAQgMU/wdT2XebsLDz5obIwLZm/Psj+GwSEQhw9AfAVKGYbh2G55A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
-        "@types/graceful-fs": "^4.1.2",
+        "@jest/types": "^29.0.3",
+        "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^27.5.1",
-        "jest-serializer": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-worker": "^27.5.1",
+        "jest-regex-util": "^29.0.0",
+        "jest-util": "^29.0.3",
+        "jest-worker": "^29.0.3",
         "micromatch": "^4.0.4",
-        "walker": "^1.0.7"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz",
-      "integrity": "sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^27.5.1",
-        "@jest/source-map": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "expect": "^27.5.1",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "pretty-format": "^27.5.1",
-        "throat": "^6.0.1"
+        "walker": "^1.0.8"
       }
     },
     "jest-leak-detector": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
-      "integrity": "sha512-POXfWAMvfU6WMUXftV4HolnJfnPOGEu10fscNCA76KBpRRhcMN2c8d3iT2pxQS3HLbA+5X4sOUPzYO2NUyIlHQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.0.3.tgz",
+      "integrity": "sha512-YfW/G63dAuiuQ3QmQlh8hnqLDe25WFY3eQhuc/Ev1AGmkw5zREblTh7TCSKLoheyggu6G9gxO2hY8p9o6xbaRQ==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "jest-get-type": "^29.0.0",
+        "pretty-format": "^29.0.3"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.3.tgz",
+      "integrity": "sha512-RsR1+cZ6p1hDV4GSCQTg+9qjeotQCgkaleIKLK7dm+U4V/H2bWedU3RAtLm8+mANzZ7eDV33dMar4pejd7047w==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "jest-diff": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "pretty-format": "^29.0.3"
       }
     },
     "jest-message-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
-      "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.0.3.tgz",
+      "integrity": "sha512-7T8JiUTtDfppojosORAflABfLsLKMLkBHSWkjNQrjIltGoDzNGn7wEPOSfjqYAGTYME65esQzMJxGDjuLBKdOg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.5.1",
+        "pretty-format": "^29.0.3",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
     },
     "jest-mock": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.5.1.tgz",
-      "integrity": "sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.0.3.tgz",
+      "integrity": "sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/node": "*"
       }
     },
@@ -8806,137 +8997,127 @@
       "requires": {}
     },
     "jest-regex-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
+      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.5.1.tgz",
-      "integrity": "sha512-FFDy8/9E6CV83IMbDpcjOhumAQPDyETnU2KZ1O98DwTnz8AOBsW/Xv3GySr1mOZdItLR+zDZ7I/UdTFbgSOVCw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.0.3.tgz",
+      "integrity": "sha512-toVkia85Y/BPAjJasTC9zIPY6MmVXQPtrCk8SmiheC4MwVFE/CMFlOtMN6jrwPMC6TtNh8+sTMllasFeu1wMPg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
+        "jest-haste-map": "^29.0.3",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
+        "jest-util": "^29.0.3",
+        "jest-validate": "^29.0.3",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.5.1.tgz",
-      "integrity": "sha512-QQOOdY4PE39iawDn5rzbIePNigfe5B9Z91GDD1ae/xNDlu9kaat8QQ5EKnNmVWPV54hUdxCVwwj6YMgR2O7IOg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.0.3.tgz",
+      "integrity": "sha512-KzuBnXqNvbuCdoJpv8EanbIGObk7vUBNt/PwQPPx2aMhlv/jaXpUJsqWYRpP/0a50faMBY7WFFP8S3/CCzwfDw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-snapshot": "^27.5.1"
+        "jest-regex-util": "^29.0.0",
+        "jest-snapshot": "^29.0.3"
       }
     },
     "jest-runner": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.5.1.tgz",
-      "integrity": "sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.0.3.tgz",
+      "integrity": "sha512-Usu6VlTOZlCZoNuh3b2Tv/yzDpKqtiNAetG9t3kJuHfUyVMNW7ipCCJOUojzKkjPoaN7Bl1f7Buu6PE0sGpQxw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.5.1",
-        "@jest/environment": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/console": "^29.0.3",
+        "@jest/environment": "^29.0.3",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "emittery": "^0.8.1",
+        "emittery": "^0.10.2",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^27.5.1",
-        "jest-environment-jsdom": "^27.5.1",
-        "jest-environment-node": "^27.5.1",
-        "jest-haste-map": "^27.5.1",
-        "jest-leak-detector": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-runtime": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-worker": "^27.5.1",
-        "source-map-support": "^0.5.6",
-        "throat": "^6.0.1"
+        "jest-docblock": "^29.0.0",
+        "jest-environment-node": "^29.0.3",
+        "jest-haste-map": "^29.0.3",
+        "jest-leak-detector": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-resolve": "^29.0.3",
+        "jest-runtime": "^29.0.3",
+        "jest-util": "^29.0.3",
+        "jest-watcher": "^29.0.3",
+        "jest-worker": "^29.0.3",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
       }
     },
     "jest-runtime": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.5.1.tgz",
-      "integrity": "sha512-o7gxw3Gf+H2IGt8fv0RiyE1+r83FJBRruoA+FXrlHw6xEyBsU8ugA6IPfTdVyA0w8HClpbK+DGJxH59UrNMx8A==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.0.3.tgz",
+      "integrity": "sha512-12gZXRQ7ozEeEHKTY45a+YLqzNDR/x4c//X6AqwKwKJPpWM8FY4vwn4VQJOcLRS3Nd1fWwgP7LU4SoynhuUMHQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.5.1",
-        "@jest/fake-timers": "^27.5.1",
-        "@jest/globals": "^27.5.1",
-        "@jest/source-map": "^27.5.1",
-        "@jest/test-result": "^27.5.1",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/environment": "^29.0.3",
+        "@jest/fake-timers": "^29.0.3",
+        "@jest/globals": "^29.0.3",
+        "@jest/source-map": "^29.0.0",
+        "@jest/test-result": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
-        "execa": "^5.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-mock": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-snapshot": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-haste-map": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-mock": "^29.0.3",
+        "jest-regex-util": "^29.0.0",
+        "jest-resolve": "^29.0.3",
+        "jest-snapshot": "^29.0.3",
+        "jest-util": "^29.0.3",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       }
     },
-    "jest-serializer": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.5.1.tgz",
-      "integrity": "sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "graceful-fs": "^4.2.9"
-      }
-    },
     "jest-snapshot": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.5.1.tgz",
-      "integrity": "sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.0.3.tgz",
+      "integrity": "sha512-52q6JChm04U3deq+mkQ7R/7uy7YyfVIrebMi6ZkBoDJ85yEjm/sJwdr1P0LOIEHmpyLlXrxy3QP0Zf5J2kj0ew==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.7.2",
+        "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
-        "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "@types/babel__traverse": "^7.0.4",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.0.3",
+        "@jest/transform": "^29.0.3",
+        "@jest/types": "^29.0.3",
+        "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.5.1",
+        "expect": "^29.0.3",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-haste-map": "^27.5.1",
-        "jest-matcher-utils": "^27.5.1",
-        "jest-message-util": "^27.5.1",
-        "jest-util": "^27.5.1",
+        "jest-diff": "^29.0.3",
+        "jest-get-type": "^29.0.0",
+        "jest-haste-map": "^29.0.3",
+        "jest-matcher-utils": "^29.0.3",
+        "jest-message-util": "^29.0.3",
+        "jest-util": "^29.0.3",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.5.1",
-        "semver": "^7.3.2"
+        "pretty-format": "^29.0.3",
+        "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
@@ -8951,12 +9132,12 @@
       }
     },
     "jest-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
-      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.3.tgz",
+      "integrity": "sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -8965,17 +9146,17 @@
       }
     },
     "jest-validate": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.5.1.tgz",
-      "integrity": "sha512-thkNli0LYTmOI1tDB3FI1S1RTp/Bqyd9pTarJwL87OIBFuqEb5Apv5EaApEudYg4g86e3CT6kM0RowkhtEnCBQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.0.3.tgz",
+      "integrity": "sha512-OebiqqT6lK8cbMPtrSoS3aZP4juID762lZvpf1u+smZnwTEBCBInan0GAIIhv36MxGaJvmq5uJm7dl5gVt+Zrw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1",
+        "@jest/types": "^29.0.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.5.1",
+        "jest-get-type": "^29.0.0",
         "leven": "^3.1.0",
-        "pretty-format": "^27.5.1"
+        "pretty-format": "^29.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -8987,24 +9168,25 @@
       }
     },
     "jest-watcher": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.5.1.tgz",
-      "integrity": "sha512-z676SuD6Z8o8qbmEGhoEUFOM1+jfEiL3DXHK/xgEiG2EyNYfFG60jluWcupY6dATjfEsKQuibReS1djInQnoVw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.0.3.tgz",
+      "integrity": "sha512-tQX9lU91A+9tyUQKUMp0Ns8xAcdhC9fo73eqA3LFxP2bSgiF49TNcc+vf3qgGYYK9qRjFpXW9+4RgF/mbxyOOw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.5.1",
-        "@jest/types": "^27.5.1",
+        "@jest/test-result": "^29.0.3",
+        "@jest/types": "^29.0.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.5.1",
+        "emittery": "^0.10.2",
+        "jest-util": "^29.0.3",
         "string-length": "^4.0.1"
       }
     },
     "jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.3.tgz",
+      "integrity": "sha512-Tl/YWUugQOjoTYwjKdfJWkSOfhufJHO5LhXTSZC3TRoQKO+fuXnZAdoXXBlpLXKGODBL3OvdUasfDD4PcMe6ng==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -9040,38 +9222,38 @@
       }
     },
     "jsdom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.0.tgz",
+      "integrity": "sha512-x4a6CKCgx00uCmP+QakBDFXwjAJ69IkkIWHmtmjd3wvXPcdOS44hfX2vqkOQrVrq8l9DhNNADZRXaCEWvgXtVA==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.5",
-        "acorn": "^8.2.4",
+        "abab": "^2.0.6",
+        "acorn": "^8.7.1",
         "acorn-globals": "^6.0.0",
-        "cssom": "^0.4.4",
+        "cssom": "^0.5.0",
         "cssstyle": "^2.3.0",
-        "data-urls": "^2.0.0",
-        "decimal.js": "^10.2.1",
-        "domexception": "^2.0.1",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.3.1",
+        "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
-        "form-data": "^3.0.0",
-        "html-encoding-sniffer": "^2.0.1",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
+        "parse5": "^7.0.0",
+        "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.0.0",
         "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^2.0.0",
-        "webidl-conversions": "^6.1.0",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.5.0",
-        "ws": "^7.4.6",
-        "xml-name-validator": "^3.0.0"
+        "w3c-xmlserializer": "^3.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.8.0",
+        "xml-name-validator": "^4.0.0"
       }
     },
     "jsesc": {
@@ -9141,16 +9323,16 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "lodash.merge": {
@@ -9182,6 +9364,12 @@
       "requires": {
         "semver": "^6.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -9363,12 +9551,12 @@
       }
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
@@ -9378,6 +9566,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-try": {
@@ -9408,10 +9607,13 @@
       }
     },
     "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
+      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "dev": true,
+      "requires": {
+        "entities": "^4.4.0"
+      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -9477,14 +9679,14 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.0.3.tgz",
+      "integrity": "sha512-cHudsvQr1K5vNVLbvYF/nv3Qy/F/BcEKxGuIeMiVMRHxPOO1RxXooP8g/ZrwAp7Dx+KdMZoOc7NxLHhMrP2f9Q==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.0.0",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9536,9 +9738,9 @@
       "dev": true
     },
     "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -9644,9 +9846,9 @@
       "dev": true
     },
     "saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
@@ -9720,9 +9922,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -9908,12 +10110,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "throat": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
-      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
-      "dev": true
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -9948,12 +10144,39 @@
       }
     },
     "tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "ts-jest": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.1.tgz",
+      "integrity": "sha512-htQOHshgvhn93QLxrmxpiQPk69+M1g7govO1g6kf6GsjCv4uvRV0znVmDrrvjUrVCnTYeY4FBxTYYYD4airyJA==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "tsconfig-paths": {
@@ -10021,21 +10244,11 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -10091,22 +10304,14 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
-      "integrity": "sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
       "dev": true,
       "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-          "dev": true
-        }
+        "convert-source-map": "^1.6.0"
       }
     },
     "w3c-hr-time": {
@@ -10119,12 +10324,12 @@
       }
     },
     "w3c-xmlserializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
+      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
       "dev": true,
       "requires": {
-        "xml-name-validator": "^3.0.0"
+        "xml-name-validator": "^4.0.0"
       }
     },
     "walker": {
@@ -10137,35 +10342,34 @@
       }
     },
     "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true
     },
     "whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "0.6.3"
       }
     },
     "whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       }
     },
     "which": {
@@ -10214,28 +10418,26 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
+        "signal-exit": "^3.0.7"
       }
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
       "requires": {}
     },
     "xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true
     },
     "xmlchars": {
@@ -10257,24 +10459,30 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       }
     },
     "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/js/package.json
+++ b/js/package.json
@@ -9,16 +9,23 @@
     "test": "jest"
   },
   "jest": {
+    "preset": "ts-jest",
     "testEnvironment": "jsdom",
     "setupFilesAfterEnv": [
       "./setupJest.js"
     ]
   },
   "devDependencies": {
+    "@types/jest": "^29.0.3",
+    "@types/node": "^18.7.18",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-testing-library": "^4.6.0",
-    "jest": "^27.5.1"
+    "jest": "^29.0.3",
+    "jest-environment-jsdom": "^29.0.3",
+    "jsdom": "^20.0.0",
+    "ts-jest": "^29.0.1",
+    "typescript": "^4.8.3"
   }
 }

--- a/js/setupJest.js
+++ b/js/setupJest.js
@@ -78,3 +78,7 @@ expect.extend({
     };
   }
 });
+const { TextEncoder, TextDecoder } = require("util");
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/js/uid2-sdk-3.0.0.ts
+++ b/js/uid2-sdk-3.0.0.ts
@@ -1,0 +1,402 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+type PromiseOutcome<T> = {
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason: any) => void;
+}
+
+enum IdentityStatus {
+    ESTABLISHED = 0,
+    REFRESHED = 1,
+    EXPIRED = 100,
+    NO_IDENTITY = -1,
+    INVALID = -2,
+    REFRESH_EXPIRED = -3,
+    OPTOUT = -4
+}
+
+class InvalidIdentityError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "InvalidIdentityError";
+    }
+}
+
+export class UID2 {
+    static get VERSION() {
+        return "3.0.0";
+    }
+    static get COOKIE_NAME() {
+        return "__uid_2";
+    }
+    static get DEFAULT_REFRESH_RETRY_PERIOD_MS() {
+        return 5000;
+    }
+    static IdentityStatus = IdentityStatus;
+
+    static setupGoogleTag() {
+        if (!window.googletag) {
+            window.googletag = {};
+        }
+        if (!window.googletag.encryptedSignalProviders) {
+            window.googletag.encryptedSignalProviders = [];
+        }
+        window.googletag.encryptedSignalProviders.push({
+            id: "uidapi.com",
+            collectorFunction: () => {
+                if (window.__uid2 && window.__uid2.getAdvertisingTokenAsync) {
+                    return window.__uid2.getAdvertisingTokenAsync();
+                } else {
+                    return Promise.reject(new Error("UID2 SDK not present"));
+                }
+            },
+        });
+    }
+
+    constructor() {
+
+    }
+        // PUBLIC METHODS
+
+    public init(opts) {
+        if (this._initCalled) {
+            throw new TypeError('Calling init() more than once is not allowed');
+        }
+
+        if (typeof opts !== 'object' || opts === null) {
+            throw new TypeError('opts must be an object');
+        } else if (typeof opts.callback !== 'function') {
+            throw new TypeError('opts.callback must be a function');
+        } else if (typeof opts.refreshRetryPeriod !== 'undefined') {
+            if (typeof opts.refreshRetryPeriod !== 'number')
+                throw new TypeError('opts.refreshRetryPeriod must be a number');
+            else if (opts.refreshRetryPeriod < 1000)
+                throw new RangeError('opts.refreshRetryPeriod must be >= 1000');
+        }
+
+        this._initCalled = true;
+        this._opts = opts;
+        let identity = this._opts.identity ? this._opts.identity : this.loadIdentity()
+        this.applyIdentity(identity);
+    };
+    public getAdvertisingToken() {
+        return this._identity && !this.temporarilyUnavailable() ? this._identity.advertising_token : undefined;
+    };
+    public getAdvertisingTokenAsync() {
+        if (!this.initialised()) {
+            return new Promise((resolve, reject) => {
+                this._promises.push({ resolve: resolve, reject: reject });
+            });
+        } else if (this._identity) {
+            return this.temporarilyUnavailable()
+                ? Promise.reject(new Error('temporarily unavailable'))
+                : Promise.resolve(this._identity.advertising_token);
+        } else {
+            return Promise.reject(new Error('identity not available'));
+        }
+    };
+    public isLoginRequired() {
+        return this.initialised() ? !this._identity : undefined;
+    };
+    public disconnect() {
+        this.abort();
+        this.removeCookie(UID2.COOKIE_NAME);
+        this._identity = undefined;
+        this._lastStatus = UID2.IdentityStatus.INVALID;
+
+        const promises = this._promises;
+        this._promises = [];
+        promises.forEach(p => p.reject(new Error("disconnect()")));
+    };
+    public abort() {
+        this._initCalled = true;
+        if (typeof this._refreshTimerId !== 'undefined') {
+            clearTimeout(this._refreshTimerId);
+            this._refreshTimerId = undefined;
+        }
+        if (this._refreshReq) {
+            this._refreshReq.abort();
+            this._refreshReq = undefined;
+        }
+    };
+
+    // PRIVATE STATE
+
+    _initCalled = false;
+    _opts;
+    _identity;
+    _lastStatus;
+    _refreshTimerId;
+    _refreshReq;
+    _refreshVersion;
+    _promises: PromiseOutcome<string>[] = [];
+
+    // PRIVATE METHODS
+
+    private initialised() { return typeof this._lastStatus !== 'undefined'; }
+    private temporarilyUnavailable() { return this._lastStatus === UID2.IdentityStatus.EXPIRED; }
+
+    private getOptionOrDefault(value, defaultValue) {
+        return typeof value === 'undefined' ? defaultValue : value;
+    };
+
+    private setCookie(name, identity) {
+        const value = JSON.stringify(identity);
+        const expires = new Date(identity.refresh_expires);
+        const path = this.getOptionOrDefault(this._opts.cookiePath, "/");
+        let cookie = name + "=" + encodeURIComponent(value) + " ;path=" + path + ";expires=" + expires.toUTCString();
+        if (typeof this._opts.cookieDomain !== 'undefined') {
+            cookie += ";domain=" + this._opts.cookieDomain;
+        }
+        document.cookie = cookie;
+    };
+    private removeCookie = (name) => {
+        document.cookie = name + "=;expires=Tue, 1 Jan 1980 23:59:59 GMT";
+    };
+    private getCookie = (name) => {
+        const docCookie = document.cookie;
+        if (docCookie) {
+            const payload = docCookie.split('; ').find(row => row.startsWith(name+'='));
+            if (payload) {
+                return decodeURIComponent(payload.split('=')[1]);
+            }
+        }
+    };
+
+    private updateStatus = (status, statusText) => {
+        this._lastStatus = status;
+
+        const promises = this._promises;
+        this._promises = [];
+
+        const advertisingToken = this.getAdvertisingToken();
+
+        const result = {
+            advertisingToken: advertisingToken,
+            advertising_token: advertisingToken,
+            status: status,
+            statusText: statusText
+        };
+        this._opts.callback(result);
+
+        if (advertisingToken) {
+            promises.forEach(p => p.resolve(advertisingToken));
+        } else {
+            promises.forEach(p => p.reject(new Error(statusText)));
+        }
+    };
+    private setValidIdentity = (identity, status, statusText) => {
+        this._identity = identity;
+        this.setCookie(UID2.COOKIE_NAME, identity);
+        this.setRefreshTimer();
+        this.updateStatus(status, statusText);
+    };
+    private setFailedIdentity = (status, statusText) => {
+        this._identity = undefined;
+        this.abort();
+        this.removeCookie(UID2.COOKIE_NAME);
+        this.updateStatus(status, statusText);
+    };
+    private checkIdentity = (identity) => {
+        if (!identity.advertising_token) {
+            throw new InvalidIdentityError("advertising_token is not available or is not valid");
+        } else if (!identity.refresh_token) {
+            throw new InvalidIdentityError("refresh_token is not available or is not valid");
+        } else if (identity.refresh_response_key) {
+            this._refreshVersion = 2;
+        } else {
+            this._refreshVersion = 1;
+        }
+    };
+    private tryCheckIdentity = (identity) => {
+        try {
+            this.checkIdentity(identity);
+            return true;
+        } catch (err) {
+            if (err instanceof InvalidIdentityError) {
+                this.setFailedIdentity(UID2.IdentityStatus.INVALID, err.message);
+                return false;
+            } else {
+                throw err;
+            }
+        }
+    };
+    private setIdentity = (identity, status, statusText) => {
+        if (this.tryCheckIdentity(identity)) {
+        this.setValidIdentity(identity, status, statusText);
+        }
+    };
+    private loadIdentity = () => {
+        const payload = this.getCookie(UID2.COOKIE_NAME);
+        if (payload) {
+            return JSON.parse(payload);
+        }
+    };
+
+    private enrichIdentity = (identity, now) => {
+        return {
+            refresh_from: now,
+            refresh_expires: now + 7 * 86400 * 1000, // 7 days
+            identity_expires: now + 4 * 3600 * 1000, // 4 hours
+            ...identity,
+        };
+    };
+    private applyIdentity = (identity) => {
+        if (!identity) {
+            this.setFailedIdentity(UID2.IdentityStatus.NO_IDENTITY, "Identity not available");
+            return;
+        }
+
+        if (!this.tryCheckIdentity(identity)) {
+            // failed identity already set
+            return;
+        }
+
+        const now = Date.now();
+        identity = this.enrichIdentity(identity, now);
+        if (identity.refresh_expires < now) {
+            this.setFailedIdentity(UID2.IdentityStatus.REFRESH_EXPIRED, "Identity expired, refresh expired");
+            return;
+        }
+        if (identity.refresh_from <= now) {
+            this.refreshToken(identity);
+            return;
+        }
+
+        if (typeof this._identity === 'undefined') {
+            this.setIdentity(identity, UID2.IdentityStatus.ESTABLISHED, "Identity established");
+        } else if (identity.advertising_token !== this._identity.advertising_token) {
+            // identity must have been refreshed from another tab
+            this.setIdentity(identity, UID2.IdentityStatus.REFRESHED, "Identity refreshed");
+        } else {
+            this.setRefreshTimer();
+        }
+    }
+
+    private createArrayBuffer = (text) => {
+        let arrayBuffer = new Uint8Array(text.length);
+        for (let i = 0; i < text.length; i++) {
+            arrayBuffer[i] = text.charCodeAt(i);
+        }
+        return arrayBuffer;
+    }
+
+    private refreshToken = (identity) => {
+        const baseUrl = this.getOptionOrDefault(this._opts.baseUrl, "https://prod.uidapi.com");
+        const url = baseUrl + "/v2/token/refresh";
+        const req = new XMLHttpRequest();
+        this._refreshReq = req;
+        req.overrideMimeType("text/plain");
+        req.open("POST", url, true);
+        req.setRequestHeader('X-UID2-Client-Version', 'uid2-sdk-' + UID2.VERSION);
+        req.onreadystatechange = () => {
+            this._refreshReq = undefined;
+            if (req.readyState !== req.DONE) return;
+            try {
+                if(this._refreshVersion === 1 || req.status !== 200) {
+                    const response = JSON.parse(req.responseText);
+                    if (!this.checkResponseStatus(identity, response)) return;
+                    this.setIdentity(response.body, UID2.IdentityStatus.REFRESHED, "Identity refreshed");
+                } else  if(this._refreshVersion === 2) {
+                    let encodeResp = this.createArrayBuffer(atob(req.responseText));
+                    window.crypto.subtle.importKey("raw", this.createArrayBuffer(atob(identity.refresh_response_key)),
+                        { name: "AES-GCM" }, false, ["decrypt"]
+                    ).then((key) => {
+                        //returns the symmetric key
+                        window.crypto.subtle.decrypt({
+                                name: "AES-GCM",
+                                iv: encodeResp.slice(0, 12), //The initialization vector you used to encrypt
+                                tagLength: 128, //The tagLength you used to encrypt (if any)
+                            },
+                            key,
+                            encodeResp.slice(12)
+                        ).then((decrypted) => {
+                            const decryptedResponse = String.fromCharCode.apply(String, new Uint8Array(decrypted));
+                            const response = JSON.parse(decryptedResponse);
+                            if (!this.checkResponseStatus(identity, response)) return;
+                            this.setIdentity(response.body, UID2.IdentityStatus.REFRESHED, "Identity refreshed");
+                        })
+                    })
+                }
+            } catch (err) {
+                this.handleRefreshFailure(identity, err.message);
+            }
+        };
+        req.send(identity.refresh_token);
+    };
+    private checkResponseStatus = (identity, response) => {
+        if (typeof response !== 'object' || response === null) {
+            throw new TypeError("refresh response is not an object");
+        }
+        if (response.status === "optout") {
+            this.setFailedIdentity(UID2.IdentityStatus.OPTOUT, "User opted out");
+            return false;
+        } else if (response.status === "expired_token") {
+            this.setFailedIdentity(UID2.IdentityStatus.REFRESH_EXPIRED, "Refresh token expired");
+            return false;
+        } else if (response.status === "success") {
+            if (typeof response.body === 'object' && response.body !== null) {
+                return true;
+            }
+            throw new TypeError("refresh response object does not have a body");
+        } else {
+            throw new TypeError("unexpected response status: " + response.status);
+        }
+    };
+    private handleRefreshFailure = (identity, errorMessage) => {
+        const now = Date.now();
+        if (identity.refresh_expires <= now) {
+            this.setFailedIdentity(UID2.IdentityStatus.REFRESH_EXPIRED, "Refresh expired; token refresh failed: " + errorMessage);
+        } else if (identity.identity_expires <= now && !this.temporarilyUnavailable()) {
+            this.setValidIdentity(identity, UID2.IdentityStatus.EXPIRED, "Token refresh failed for expired identity: " + errorMessage);
+        } else if (this.initialised()) {
+            this.setRefreshTimer(); // silently retry later
+        } else {
+            this.setIdentity(identity, UID2.IdentityStatus.ESTABLISHED, "Identity established; token refresh failed: " + errorMessage)
+        }
+    };
+    private setRefreshTimer = () => {
+        const timeout = this.getOptionOrDefault(this._opts.refreshRetryPeriod, UID2.DEFAULT_REFRESH_RETRY_PERIOD_MS);
+        this._refreshTimerId = setTimeout(() => {
+            if (this.isLoginRequired()) return;
+            this.applyIdentity(this.loadIdentity());
+        }, timeout);
+    };
+
+
+}
+
+
+declare global {
+    interface Window {
+        googletag: any;
+        __uid2: UID2;
+    }
+}
+
+window.__uid2 = new UID2();
+
+UID2.setupGoogleTag();
+
+export const sdkWindow = globalThis.window;

--- a/js/uid2-sdk-3.0.0/async.spec.ts
+++ b/js/uid2-sdk-3.0.0/async.spec.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {expect, jest, describe, test, beforeEach, afterEach} from '@jest/globals';
+import {sdkWindow, UID2} from '../uid2-sdk-3.0.0';
+import * as mocks from '../mocks.js';
+
+let callback;
+let uid2;
+let xhrMock;
+// eslint-disable-next-line no-unused-vars
+let cryptoMock;
+mocks.setupFakeTime();
+
+beforeEach(() => {
+  callback = jest.fn();
+  uid2 = new UID2();
+  xhrMock = new mocks.XhrMock(window);
+  cryptoMock = new mocks.CryptoMock(window);
+  mocks.setCookieMock(window.document);
+});
+
+afterEach(() => {
+  mocks.resetFakeTime();
+});
+
+const makeIdentity = mocks.makeIdentityV2;
+
+describe('when getAdvertisingTokenAsync is called before init', () => {
+  describe('when initialising with a valid identity', () => {
+    const identity = makeIdentity();
+    test('it should resolve promise after invoking the callback', () => {
+      const p = uid2.getAdvertisingTokenAsync().then(token => {
+        expect(callback).toHaveBeenCalled();
+        return token;
+      });
+      uid2.init({ callback: callback, identity: identity });
+      jest.runAllTimers();
+      return expect(p).resolves.toBe(identity.advertising_token);
+    });
+  });
+
+  describe('when initialising with an invalid identity', () => {
+    test('it should reject promise after invoking the callback', () => {
+      const p = uid2.getAdvertisingTokenAsync().catch(e => {
+        expect(callback).toHaveBeenCalled();
+        throw e;
+      });
+      uid2.init({ callback: callback });
+      return expect(p).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when auto refresh fails due to optout', () => {
+    test('it should reject promise after invoking the callback', () => {
+      const originalIdentity = makeIdentity({
+        refresh_from: Date.now() - 100000,
+      });
+      const p = uid2.getAdvertisingTokenAsync().catch(e => {
+        expect(callback).toHaveBeenCalled();
+        throw e;
+      });
+      uid2.init({ callback: callback, identity: originalIdentity });
+      xhrMock.responseText = JSON.stringify({ status: 'optout' });
+      xhrMock.status = 400;
+      xhrMock.onreadystatechange(new Event(''));
+      return expect(p).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when auto refresh fails, but identity still valid', () => {
+    test('it should reject promise after invoking the callback', () => {
+      const originalIdentity = makeIdentity({
+        refresh_from: Date.now() - 100000,
+      });
+      const p = uid2.getAdvertisingTokenAsync().then(token => {
+        expect(callback).toHaveBeenCalled();
+        return token;
+      });
+      uid2.init({ callback: callback, identity: originalIdentity });
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+      //return expect(p).resolves.toBe(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when auto refresh fails, but identity already expired', () => {
+    test('it should reject promise after invoking the callback', () => {
+      const originalIdentity = makeIdentity({
+        refresh_from: Date.now() - 100000,
+        identity_expires: Date.now() - 1
+      });
+      const p = uid2.getAdvertisingTokenAsync().catch(e => {
+        expect(callback).toHaveBeenCalled();
+        throw e;
+      });
+      uid2.init({ callback: callback, identity: originalIdentity });
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+      return expect(p).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when giving multiple promises', () => {
+    const identity = makeIdentity();
+    test('it should resolve all promises', () => {
+      const p1 = uid2.getAdvertisingTokenAsync();
+      const p2 = uid2.getAdvertisingTokenAsync();
+      const p3 = uid2.getAdvertisingTokenAsync();
+      uid2.init({ callback: callback, identity: identity });
+      //return expect(Promise.all([p1, p2, p3])).resolves.toStrictEqual(Array(3).fill(identity.advertising_token));
+    });
+  });
+});
+
+describe('when getAdvertisingTokenAsync is called after init completed', () => {
+  describe('when initialised with a valid identity', () => {
+    const identity = makeIdentity();
+    test('it should resolve promise', () => {
+      uid2.init({ callback: callback, identity: identity });
+      // return expect(uid2.getAdvertisingTokenAsync()).resolves.toBe(identity.advertising_token);
+    });
+  });
+
+  describe('when initialisation failed', () => {
+    test('it should reject promise', () => {
+      uid2.init({ callback: callback });
+      return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when identity is temporarily not available', () => {
+    test('it should reject promise', () => {
+      const originalIdentity = makeIdentity({
+        refresh_from: Date.now() - 100000,
+        identity_expires: Date.now() - 1
+      });
+      uid2.init({ callback: callback, identity: originalIdentity });
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+      return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when disconnect() has been called', () => {
+    test('it should reject promise', () => {
+      uid2.init({ callback: callback, identity: makeIdentity() });
+      uid2.disconnect();
+      return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
+    });
+  });
+});
+
+describe('when getAdvertisingTokenAsync is called before refresh on init completes', () => {
+  const originalIdentity = makeIdentity({
+    refresh_from: Date.now() - 100000,
+  });
+  const updatedIdentity = makeIdentity({
+    advertising_token: 'updated_advertising_token'
+  });
+
+  beforeEach(() => {
+    uid2.init({ callback: callback, identity: originalIdentity });
+  });
+
+  describe('when auto refresh completes successfully', () => {
+    test('it should resolve promise after invoking the callback', () => {
+      const p = uid2.getAdvertisingTokenAsync().then(token => {
+        expect(callback).toHaveBeenCalled();
+        return token;
+      });
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'success', body: updatedIdentity }));
+      xhrMock.onreadystatechange(new Event(''));
+      // return expect(p).resolves.toBe(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when disconnect() has been called', () => {
+    test('it should reject promise', () => {
+      const p = uid2.getAdvertisingTokenAsync();
+      uid2.disconnect();
+      return expect(p).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when promise obtained after disconnect', () => {
+    test('it should reject promise', () => {
+      uid2.disconnect();
+      return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
+    });
+  });
+});

--- a/js/uid2-sdk-3.0.0/autoRefresh.test.ts
+++ b/js/uid2-sdk-3.0.0/autoRefresh.test.ts
@@ -1,0 +1,386 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {expect, jest, describe, test, beforeEach, afterEach} from '@jest/globals';
+import {sdkWindow, UID2} from '../uid2-sdk-3.0.0';
+import * as mocks from '../mocks.js';
+
+let callback;
+let uid2: UID2;
+let xhrMock;
+// eslint-disable-next-line no-unused-vars
+let cryptoMock;
+
+mocks.setupFakeTime();
+
+beforeEach(() => {
+  callback = jest.fn();
+  uid2 = new UID2();
+  xhrMock = new mocks.XhrMock(sdkWindow);
+  cryptoMock = new mocks.CryptoMock(sdkWindow);
+  mocks.setCookieMock(sdkWindow.document);
+});
+
+afterEach(() => {
+  mocks.resetFakeTime();
+});
+
+const getUid2Cookie = mocks.getUid2Cookie;
+const makeIdentity = mocks.makeIdentityV2;
+
+describe('when auto refreshing a non-expired identity which does not require a refresh', () => {
+  beforeEach(() => {
+    uid2.init({ callback: callback, identity: makeIdentity() });
+    jest.clearAllMocks();
+    jest.runOnlyPendingTimers();
+  });
+
+  test('should not invoke the callback', () => {
+    console.log(sdkWindow.crypto);
+    expect(sdkWindow.crypto).toBeDefined();
+    expect(callback).not.toHaveBeenCalled();
+  });
+  test('should not initiate token refresh', () => {
+    expect(xhrMock.send).not.toHaveBeenCalled();
+  });
+  test('should set refresh timer', () => {
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+  test('should be in available state', () => {
+    (expect(uid2) as any).toBeInAvailableState();
+  });
+});
+
+describe('when auto refreshing a non-expired identity which requires a refresh', () => {
+  const refreshFrom = Date.now() + 100;
+  const originalIdentity = makeIdentity({
+    advertising_token: 'original_advertising_token',
+    refresh_from: refreshFrom
+  });
+  const updatedIdentity = makeIdentity({
+    advertising_token: 'updated_advertising_token'
+  });
+
+  beforeEach(() => {
+    uid2.init({ callback: callback, identity: originalIdentity });
+    jest.clearAllMocks();
+    jest.setSystemTime(refreshFrom);
+    jest.runOnlyPendingTimers();
+  });
+
+  test('should not invoke the callback', () => {
+    expect(callback).not.toHaveBeenCalled();
+  });
+  test('should initiate token refresh', () => {
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+  });
+  test('should not set refresh timer', () => {
+    expect(setTimeout).not.toHaveBeenCalled();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+  test('should be in available state', () => {
+    (expect(uid2) as any).toBeInAvailableState();
+  });
+
+  describe('when token refresh succeeds', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'success', body: updatedIdentity }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
+        advertising_token: updatedIdentity.advertising_token,
+        status: UID2.IdentityStatus.REFRESHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(updatedIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns optout', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'optout' }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.OPTOUT,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns refresh token expired', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'expired_token' }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns an error status', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'error', body: updatedIdentity });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should not invoke the callback', () => {
+      expect(callback).not.toHaveBeenCalled();
+    });
+    test('should not update cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh fails and current identity expires', () => {
+    beforeEach(() => {
+      jest.setSystemTime(originalIdentity.refresh_expires * 1000 + 1);
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+});
+
+describe('when auto refreshing an expired identity', () => {
+  const refreshFrom = Date.now() + 100;
+  const originalIdentity = makeIdentity({
+    advertising_token: 'original_advertising_token',
+    identity_expires: refreshFrom,
+    refresh_from: refreshFrom
+  });
+  const updatedIdentity = makeIdentity({
+    advertising_token: 'updated_advertising_token'
+  });
+
+  beforeEach(() => {
+    uid2.init({ callback: callback, identity: originalIdentity });
+    jest.clearAllMocks();
+    jest.setSystemTime(refreshFrom);
+    jest.runOnlyPendingTimers();
+  });
+
+  test('should not invoke the callback', () => {
+    expect(callback).not.toHaveBeenCalled();
+  });
+  test('should initiate token refresh', () => {
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+  });
+  test('should not set refresh timer', () => {
+    expect(setTimeout).not.toHaveBeenCalled();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+  test('should be in available state', () => {
+    (expect(uid2) as any).toBeInAvailableState();
+  });
+
+  describe('when token refresh succeeds', () => {
+    beforeEach(() => {
+    xhrMock.responseText = btoa(JSON.stringify({ status: 'success', body: updatedIdentity }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
+        advertising_token: updatedIdentity.advertising_token,
+        status: UID2.IdentityStatus.REFRESHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(updatedIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns optout', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'optout' }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.OPTOUT,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns refresh token expired', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'expired_token' }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns an error status', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'error', body: updatedIdentity });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.EXPIRED,
+      }));
+    });
+    test('should not update cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in temporarily unavailable state', () => {
+      (expect(uid2) as any).toBeInTemporarilyUnavailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh fails and current identity expires', () => {
+    beforeEach(() => {
+      jest.setSystemTime(originalIdentity.refresh_expires * 1000 + 1);
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+});

--- a/js/uid2-sdk-3.0.0/basic.test.ts
+++ b/js/uid2-sdk-3.0.0/basic.test.ts
@@ -1,0 +1,826 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {expect, jest, describe, test, beforeEach, afterEach} from '@jest/globals';
+import {sdkWindow, UID2} from '../uid2-sdk-3.0.0';
+import * as mocks from '../mocks.js';
+
+let callback;
+let uid2: UID2;
+let xhrMock;
+
+mocks.setupFakeTime();
+
+beforeEach(() => {
+  callback = jest.fn();
+  uid2 = new UID2();
+  xhrMock = new mocks.XhrMock(sdkWindow);
+  mocks.setCookieMock(sdkWindow.document);
+});
+
+afterEach(() => {
+  mocks.resetFakeTime();
+});
+
+const setUid2Cookie = mocks.setUid2Cookie;
+const getUid2Cookie = mocks.getUid2Cookie;
+const makeIdentityV1 = mocks.makeIdentityV1;
+const makeIdentityV2 = mocks.makeIdentityV2;
+
+describe('When google tag setup is called', () => {
+  test('should not fail when there is no googletag', () => {
+    sdkWindow.googletag = null;
+    expect(() => UID2.setupGoogleTag()).not.toThrow(TypeError);
+  });
+  test('should not fail when there is no googletag encryptedSignalProviders', () => {
+    sdkWindow.googletag = { encryptedSignalProviders: null };
+    expect(() => UID2.setupGoogleTag()).not.toThrow(TypeError);
+  });
+  test('should push if googletag has encryptedSignalProviders', () => {
+    const mockPush = jest.fn();
+    sdkWindow.googletag = { encryptedSignalProviders: { push: mockPush } };
+    UID2.setupGoogleTag();
+    expect(mockPush.mock.calls.length).toBe(1);
+  });
+});
+
+describe('initial state before init() is called', () => {
+  test('should be in initialising state', () => {
+    (expect(uid2) as any).toBeInInitialisingState();
+  });
+
+  test('getAdvertisingToken should return undefined', () => {
+    expect(uid2.getAdvertisingToken()).toBeUndefined();
+  });
+});
+
+describe('when initialising with invalid options', () => {
+  test('should fail on no opts', () => {
+    expect(() => (uid2 as any).init()).toThrow(TypeError);
+  });
+  test('should fail on opts not being an object', () => {
+    expect(() => uid2.init(12345)).toThrow(TypeError);
+  });
+  test('should fail on opts being null', () => {
+    expect(() => uid2.init(null)).toThrow(TypeError);
+  });
+  test('should fail on no callback provided', () => {
+    expect(() => uid2.init({ })).toThrow(TypeError);
+  });
+  test('should fail on callback not being a function', () => {
+    expect(() => uid2.init({ callback: 12345 })).toThrow(TypeError);
+  });
+  test('should fail on refreshRetryPeriod not being a number', () => {
+    expect(() => uid2.init({ callback: () => {}, refreshRetryPeriod: 'abc' })).toThrow(TypeError);
+  });
+  test('should fail on refreshRetryPeriod being less than 1 second', () => {
+    expect(() => uid2.init({ callback: () => {}, refreshRetryPeriod: 1 })).toThrow(RangeError);
+  });
+});
+
+test('init() should fail if called multiple times', () => {
+  uid2.init({ callback: () => {} });
+  expect(() => uid2.init({ callback: () => {} })).toThrow();
+});
+
+describe('when initialised without identity', () => {
+  describe('when uid2 cookie is not available', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.NO_IDENTITY,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when uid2 cookie with invalid JSON is available', () => {
+    beforeEach(() => {
+      setUid2Cookie({});
+      uid2.init({ callback: callback });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.INVALID,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when uid2 cookie with up-to-date identity is available v2', () => {
+    const identity = makeIdentityV2();
+
+    beforeEach(() => {
+      setUid2Cookie(identity);
+      uid2.init({ callback: callback });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
+        advertising_token: identity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(identity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
+    });
+  });
+
+  describe('when uid2 cookie with expired refresh is available', () => {
+    const identity = makeIdentityV2({
+      refresh_expires: Date.now() - 100000
+    });
+
+    beforeEach(() => {
+      setUid2Cookie(identity);
+      uid2.init({ callback: callback });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when uid2 cookie with valid but refreshable identity is available', () => {
+    const identity = makeIdentityV2({
+      refresh_from: Date.now() - 100000
+    });
+
+    beforeEach(() => {
+      setUid2Cookie(identity);
+      uid2.init({ callback: callback });
+    });
+
+    test('should initiate token refresh', () => {
+      expect(xhrMock.send).toHaveBeenCalledTimes(1);
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in initialising state', () => {
+      (expect(uid2) as any).toBeInInitialisingState();
+    });
+  });
+
+  describe('when uid2 v2 cookie with expired but refreshable identity is available', () => {
+    const identity = makeIdentityV2({
+      identity_expires: Date.now() - 100000,
+      refresh_from: Date.now() - 100000
+    });
+
+    beforeEach(() => {
+      setUid2Cookie(identity);
+      uid2.init({ callback: callback });
+    });
+
+    test('should initiate token refresh', () => {
+      let cryptoMock = new mocks.CryptoMock(sdkWindow);
+      expect(xhrMock.send).toHaveBeenCalledTimes(1);
+      let url = "https://prod.uidapi.com/v2/token/refresh";
+      expect(xhrMock.open).toHaveBeenLastCalledWith("POST", url, true);
+      expect(xhrMock.send).toHaveBeenLastCalledWith(identity.refresh_token);
+      xhrMock.onreadystatechange();
+      expect(cryptoMock.subtle.importKey).toHaveBeenCalled();
+    });
+
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in initialising state', () => {
+      (expect(uid2) as any).toBeInInitialisingState();
+    });
+  });
+  describe('when uid2 v1 cookie with expired but refreshable identity is available', () => {
+    const identity = makeIdentityV1({
+      identity_expires: Date.now() - 100000,
+      refresh_from: Date.now() - 100000
+    });
+
+    beforeEach(() => {
+      setUid2Cookie(identity);
+      uid2.init({ callback: callback });
+    });
+
+    test('should initiate token refresh', () => {
+      let cryptoMock = new mocks.CryptoMock(sdkWindow);
+      expect(xhrMock.send).toHaveBeenCalledTimes(1);
+      let url = "https://prod.uidapi.com/v2/token/refresh";
+      expect(xhrMock.open).toHaveBeenLastCalledWith("POST", url, true);
+      expect(xhrMock.send).toHaveBeenLastCalledWith(identity.refresh_token);
+      xhrMock.onreadystatechange();
+      expect(cryptoMock.subtle.importKey).toHaveBeenCalledTimes(0);
+    });
+  });
+});
+
+describe('when initialised with specific identity', () => {
+  describe('when invalid identity is supplied', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: {} });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.INVALID,
+      }));
+    });
+    test('should clear cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when valid v2 identity is supplied', () => {
+    const identity = makeIdentityV2();
+
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: identity });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
+        advertising_token: identity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(identity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
+    });
+  });
+
+  describe('when valid identity is supplied and cookie is available', () => {
+    const initIdentity = makeIdentityV2({
+      advertising_token: 'init_advertising_token'
+    });
+    const cookieIdentity = makeIdentityV2({
+      advertising_token: 'cookie_advertising_token'
+    });
+
+    beforeEach(() => {
+      setUid2Cookie(cookieIdentity);
+      uid2.init({ callback: callback, identity: initIdentity });
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: initIdentity.advertising_token,
+        advertising_token: initIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(initIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(initIdentity.advertising_token);
+    });
+  });
+});
+
+describe('when still valid identity is refreshed on init', () => {
+  const originalIdentity = makeIdentityV2({
+    advertising_token: 'original_advertising_token',
+    refresh_from: Date.now() - 100000
+  });
+  const updatedIdentity = makeIdentityV2({
+    advertising_token: 'updated_advertising_token'
+  });
+
+  beforeEach(() => {
+    uid2.init({ callback: callback, identity: originalIdentity });
+  });
+
+  describe('when token refresh succeeds', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'success', body: updatedIdentity }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
+        advertising_token: updatedIdentity.advertising_token,
+        status: UID2.IdentityStatus.REFRESHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(updatedIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns invalid response', () => {
+    beforeEach(() => {
+      xhrMock.responseText = 'abc';
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
+        advertising_token: originalIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns optout', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'optout' }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.OPTOUT,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns expired token', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'expired_token' });
+      xhrMock.status = 400;
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns an error status', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'error', body: updatedIdentity });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
+        advertising_token: originalIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns no body', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'success' });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
+        advertising_token: originalIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns incorrect body type', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'success', body: 5 });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
+        advertising_token: originalIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns invalid body', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'success', body: {} });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
+        advertising_token: originalIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh fails and current identity expires', () => {
+    beforeEach(() => {
+      jest.setSystemTime(originalIdentity.refresh_expires * 1000 + 1);
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+});
+
+describe('when expired identity is refreshed on init', () => {
+  const originalIdentity = makeIdentityV2({
+    advertising_token: 'original_advertising_token',
+    refresh_from: Date.now() - 100000,
+    identity_expires: Date.now() - 1
+  });
+  const updatedIdentity = makeIdentityV2({
+    advertising_token: 'updated_advertising_token'
+  });
+
+  beforeEach(() => {
+    uid2.init({ callback: callback, identity: originalIdentity });
+  });
+
+  describe('when token refresh succeeds', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'success', body: updatedIdentity }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
+        advertising_token: updatedIdentity.advertising_token,
+        status: UID2.IdentityStatus.REFRESHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(updatedIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns optout', () => {
+    beforeEach(() => {
+      xhrMock.responseText = btoa(JSON.stringify({ status: 'optout' }));
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.OPTOUT,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns expired token', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'expired_token' });
+      xhrMock.status = 400;
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+
+  describe('when token refresh returns an error status', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'error', body: updatedIdentity });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.EXPIRED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(originalIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in temporarily unavailable state', () => {
+      (expect(uid2) as any).toBeInTemporarilyUnavailableState();
+    });
+  });
+
+  describe('when token refresh fails and current identity expires', () => {
+    beforeEach(() => {
+      jest.setSystemTime(originalIdentity.refresh_expires * 1000 + 1);
+      xhrMock.responseText = JSON.stringify({ status: 'error' });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
+        advertising_token: undefined,
+        status: UID2.IdentityStatus.REFRESH_EXPIRED,
+      }));
+    });
+    test('should not set cookie', () => {
+      expect(getUid2Cookie()).toBeUndefined();
+    });
+    test('should not set refresh timer', () => {
+      expect(setTimeout).not.toHaveBeenCalled();
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in unavailable state', () => {
+      (expect(uid2) as any).toBeInUnavailableState();
+    });
+  });
+});
+
+describe('abort()', () => {
+  test('should not clear cookie', () => {
+    const identity = makeIdentityV2();
+    setUid2Cookie(identity);
+    uid2.abort();
+    expect(getUid2Cookie().advertising_token).toBe(identity.advertising_token);
+  });
+  test('should abort refresh timer', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2() });
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).not.toHaveBeenCalled();
+    uid2.abort();
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).toHaveBeenCalledTimes(1);
+  });
+  test('should not abort refresh timer if not timer is set', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2({ refresh_from: Date.now() - 100000 }) });
+    expect(setTimeout).not.toHaveBeenCalled();
+    expect(clearTimeout).not.toHaveBeenCalled();
+    uid2.abort();
+    expect(setTimeout).not.toHaveBeenCalled();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+  test('should abort refresh token request', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2({ refresh_from: Date.now() - 100000 }) });
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+    expect(xhrMock.abort).not.toHaveBeenCalled();
+    uid2.abort();
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+    expect(xhrMock.abort).toHaveBeenCalledTimes(1);
+  });
+  test('should prevent subsequent calls to init()', () => {
+    uid2.abort();
+    expect(() => uid2.init({ callback: () => {} })).toThrow();
+  });
+});
+
+describe('disconnect()', () => {
+  test('should clear cookie', () => {
+    setUid2Cookie(makeIdentityV2());
+    uid2.disconnect();
+    expect(getUid2Cookie()).toBeUndefined();
+  });
+  test('should abort refresh timer', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2() });
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).not.toHaveBeenCalled();
+    uid2.disconnect();
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).toHaveBeenCalledTimes(1);
+  });
+  test('should abort refresh token request', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2({ refresh_from: Date.now() - 100000 }) });
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+    expect(xhrMock.abort).not.toHaveBeenCalled();
+    uid2.disconnect();
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+    expect(xhrMock.abort).toHaveBeenCalledTimes(1);
+  });
+  test('should not invoke callback after aborting refresh token request', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2({ refresh_from: Date.now() - 100000 }) });
+    uid2.disconnect();
+    expect(callback).not.toHaveBeenCalled();
+  });
+  test('should prevent subsequent calls to init()', () => {
+    uid2.disconnect();
+    expect(() => uid2.init({ callback: () => {} })).toThrow();
+  });
+  test('should switch to unavailable state', () => {
+    uid2.init({ callback: callback, identity: makeIdentityV2() });
+    uid2.disconnect();
+    (expect(uid2) as any).toBeInUnavailableState();
+  });
+});

--- a/js/uid2-sdk-3.0.0/compatibility.test.ts
+++ b/js/uid2-sdk-3.0.0/compatibility.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {expect, jest, describe, test, beforeEach, afterEach} from '@jest/globals';
+import {sdkWindow, UID2} from '../uid2-sdk-3.0.0';
+import * as mocks from '../mocks.js';
+
+let callback;
+let uid2;
+let xhrMock;
+
+mocks.setupFakeTime();
+
+beforeEach(() => {
+  callback = jest.fn();
+  uid2 = new UID2();
+  xhrMock = new mocks.XhrMock(sdkWindow);
+  mocks.setCookieMock(sdkWindow.document);
+});
+
+afterEach(() => {
+  mocks.resetFakeTime();
+});
+
+const setUid2Cookie = mocks.setUid2Cookie;
+const getUid2Cookie = mocks.getUid2Cookie;
+const makeIdentity = mocks.makeIdentityV2;
+
+describe('when a v0 cookie is available', () => {
+  const originalIdentity = {
+    advertising_token: 'original_advertising_token',
+    refresh_token: 'original_refresh_token',
+  };
+  const updatedIdentity = makeIdentity({
+    advertising_token: 'updated_advertising_token'
+  });
+
+  beforeEach(() => {
+      setUid2Cookie(originalIdentity);
+      uid2.init({ callback: callback });
+  });
+
+  test('should initiate token refresh', () => {
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+  });
+  test('should not set refresh timer', () => {
+    expect(setTimeout).not.toHaveBeenCalled();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+  test('should be in initialising state', () => {
+    (expect(uid2) as any).toBeInInitialisingState();
+  });
+
+  describe('when token refresh succeeds', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'success', body: updatedIdentity });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertising_token: updatedIdentity.advertising_token,
+        status: UID2.IdentityStatus.REFRESHED,
+      }));
+    });
+    test('should set cookie', () => {
+      expect(getUid2Cookie().advertising_token).toBe(updatedIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when token refresh returns an error status', () => {
+    beforeEach(() => {
+      xhrMock.responseText = JSON.stringify({ status: 'error', body: updatedIdentity });
+      xhrMock.onreadystatechange(new Event(''));
+    });
+
+    test('should invoke the callback', () => {
+      expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
+        advertising_token: originalIdentity.advertising_token,
+        status: UID2.IdentityStatus.ESTABLISHED,
+      }));
+    });
+    test('should set enriched cookie', () => {
+      expect(getUid2Cookie().refresh_token).toBe(originalIdentity.refresh_token);
+      expect(getUid2Cookie().refresh_from).toBe(Date.now());
+      expect(getUid2Cookie().identity_expires).toBeGreaterThan(Date.now());
+      expect(getUid2Cookie().refresh_expires).toBeGreaterThan(Date.now());
+      expect(getUid2Cookie().identity_expires).toBeLessThan(getUid2Cookie().refresh_expires);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(originalIdentity.advertising_token);
+    });
+  });
+});

--- a/js/uid2-sdk-3.0.0/options.test.ts
+++ b/js/uid2-sdk-3.0.0/options.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import {expect, jest, describe, test, beforeEach, afterEach} from '@jest/globals';
+import {sdkWindow, UID2} from '../uid2-sdk-3.0.0';
+import * as mocks from '../mocks.js';
+
+let callback;
+let uid2;
+let xhrMock;
+let cookieMock;
+
+mocks.setupFakeTime();
+
+const mockDomain = 'www.uidapi.com';
+const mockUrl = `http://${mockDomain}/test/index.html`;
+
+beforeEach(() => {
+  callback = jest.fn();
+  uid2 = new UID2();
+  xhrMock = new mocks.XhrMock(sdkWindow);
+  jest.spyOn(document, 'URL', 'get').mockImplementation(() => mockUrl);
+  cookieMock = new mocks.CookieMock(sdkWindow.document);
+});
+
+afterEach(() => {
+  mocks.resetFakeTime();
+});
+
+const makeIdentity = mocks.makeIdentityV2;
+
+describe('cookieDomain option', () => {
+  describe('when using default value', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: makeIdentity() });
+    });
+
+    test('should not mention domain in the cookie string', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie).not.toBe('');
+      expect(cookie).not.toContain('Domain=');
+    });
+  });
+
+  describe('when using custom value', () => {
+    const domain = 'uidapi.com';
+
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: makeIdentity(), cookieDomain: domain });
+    });
+
+    test('should use domain in the cookie string', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie).toContain(`Domain=${domain};`);
+    });
+  });
+});
+
+describe('cookiePath option', () => {
+  describe('when using default value', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: makeIdentity() });
+    });
+
+    test('should use the default path in the cookie string', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie+';').toContain('Path=/;');
+    });
+  });
+
+  describe('when using custom value', () => {
+    const path = '/test/';
+
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: makeIdentity(), cookiePath: path });
+    });
+
+    test('should use custom path in the cookie string', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie+';').toContain(`Path=${path};`);
+    });
+  });
+});
+
+describe('baseUrl option', () => {
+  const identity = makeIdentity({
+    refresh_from: Date.now()- 100000
+  });
+
+  describe('when using default value', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: identity });
+    });
+
+    test('should use prod URL when refreshing token', () => {
+      expect(xhrMock.open.mock.calls.length).toBe(1);
+      expect(xhrMock.open.mock.calls[0][1]).toContain('prod.uidapi.com');
+    });
+  });
+
+  describe('when using custom value', () => {
+    const baseUrl = 'http://test-host';
+
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: identity, baseUrl: baseUrl });
+    });
+
+    test('should use custom URL when refreshing token', () => {
+      expect(xhrMock.open.mock.calls.length).toBe(1);
+      expect(xhrMock.open.mock.calls[0][1]).not.toContain('prod.uidapi.com');
+      expect(xhrMock.open.mock.calls[0][1]).toContain('test-host');
+    });
+  });
+});
+
+describe('refreshRetryPeriod option', () => {
+  describe('when using default value', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: makeIdentity() });
+    });
+
+    test('it should use the default retry period', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toBeCalledWith(expect.any(Function), UID2.DEFAULT_REFRESH_RETRY_PERIOD_MS);
+    });    
+  });
+
+  describe('when using custom value', () => {
+    beforeEach(() => {
+      uid2.init({ callback: callback, identity: makeIdentity(), refreshRetryPeriod: 12345 });
+    });
+
+    test('it should use the default retry period', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toBeCalledWith(expect.any(Function), 12345);
+    });
+  });
+});

--- a/js/uid2-sdk-3.0.0/testEnvironment.test.ts
+++ b/js/uid2-sdk-3.0.0/testEnvironment.test.ts
@@ -1,0 +1,6 @@
+import {sdkWindow, UID2} from '../uid2-sdk-3.0.0';
+import { test } from '@jest/globals';
+
+test('Init can be constructed', () => {
+    const uid2 = new UID2();
+});


### PR DESCRIPTION
… replace window.crypto more reliably.

Add typescript.
Add ts-jest and types.
Update jest.
Add minimal TypeScript port of 2.1 as 3.0 (fewest possible changes to get it working and all tests passing). Add 3.0 versions of tests.